### PR TITLE
Add /presences for setting bot presence at runtime

### DIFF
--- a/src/controllers/dev/presence.controller.ts
+++ b/src/controllers/dev/presence.controller.ts
@@ -1,0 +1,121 @@
+import {
+  APIApplicationCommandOptionChoice,
+  ActivityType,
+  CommandInteractionOptionResolver,
+  PresenceUpdateStatus,
+  SlashCommandBuilder,
+} from "discord.js";
+
+import getLogger from "../../logger";
+import {
+  RoleLevel,
+  checkPrivilege,
+} from "../../middleware/privilege.middleware";
+import { Command, Controller } from "../../types/controller.types";
+import { iterateEnum } from "../../utils/iteration.utils";
+import { formatContext } from "../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+type Choice<T> = APIApplicationCommandOptionChoice<T>;
+type ActivityTypeName = keyof typeof ActivityType;
+type PresenceUpdateStatusName
+  = Exclude<keyof typeof PresenceUpdateStatus, "Offline">;
+
+const activityTypeNames: ActivityTypeName[]
+  = iterateEnum(ActivityType)
+    .map(([name]) => name)
+    // TODO: enum values (numbers) being included through iterateEnum somehow.
+    .filter(name => isNaN(Number(name)));
+const activityChoices: Choice<ActivityTypeName>[]
+  = activityTypeNames.map(name => ({ name, value: name }));
+
+const statusTypeNames: PresenceUpdateStatusName[]
+  = ["Online", "DoNotDisturb", "Idle", "Invisible"];
+const statusChoices: Choice<PresenceUpdateStatusName>[]
+  = statusTypeNames.map(name => ({ name, value: name }));
+
+const changePresence = new Command(new SlashCommandBuilder()
+  .setName("presence")
+  .setDescription("Update bot presence.")
+  .addStringOption(input => input
+    .setName("activity_type")
+    .setDescription("Activity type (determines the verb used).")
+    .addChoices(...activityChoices)
+  )
+  .addStringOption(input => input
+    .setName("activity_name")
+    .setDescription("Text to follow the activity verb.")
+  )
+  .addStringOption(input => input
+    .setName("status")
+    .setDescription("Status of the bot.")
+    .addChoices(...statusChoices)
+  )
+  .addBooleanOption(input => input
+    .setName("clear_activity")
+    .setDescription("Clear current activity (ignores other activity options)")
+  )
+);
+
+changePresence.check(checkPrivilege(RoleLevel.DEV));
+changePresence.execute(async (interaction) => {
+  const context = formatContext(interaction);
+  const { client } = interaction;
+
+  const options = interaction.options as CommandInteractionOptionResolver;
+  const activityName
+    = options.getString("activity_name") as string | null;
+  const activityType
+    = options.getString("activity_type") as ActivityTypeName | null;
+  const status
+    = options.getString("status") as PresenceUpdateStatusName | null;
+  const clearActivity
+    = options.getBoolean("clear_activity") as boolean | null;
+
+  // Ignore the other activity options and just clear the activity.
+  if (clearActivity) {
+    client.user.setActivity();
+  } else {
+    // Activity requires a name. Type is optional. If the caller specifies a
+    // type without a name, we can't make the API call, so it's an error.
+    if (activityType && !activityName) {
+      log.debug(`${context}: attempted to set bot activity without a name`);
+      await interaction.reply({
+        content: "Activity requires a name!",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    if (activityName) {
+      const activityTypeValue = activityType
+        ? ActivityType[activityType]
+        : undefined;
+      client.user.setActivity({
+        name: activityName,
+        type: activityTypeValue,
+      });
+      log.info(
+        `${context}: set bot activity to ` +
+        `(${activityTypeValue}, ${activityName}).`
+      );
+    }
+  }
+
+  if (status) {
+    const statusValue = PresenceUpdateStatus[status];
+    client.user.setStatus(statusValue);
+    log.info(`${context}: set bot status to ${statusValue}.`);
+  }
+
+  await interaction.reply("👍");
+});
+
+const controller: Controller = {
+  name: "presence",
+  commands: [changePresence],
+  listeners: [],
+};
+
+export default controller;

--- a/src/utils/iteration.utils.ts
+++ b/src/utils/iteration.utils.ts
@@ -10,6 +10,9 @@
  *      // member is typed as SomeEnum instead of string.
  *    }
  *    ```
+ *
+ * NOTE: This doesn't seem to work as expected! When iterating over a numeric
+ * enum, the numbers seem to be included as part of the keys.
  */
 export function iterateEnum<T extends {}>(enumerable: T)
   : [keyof T, T[keyof T]][] {


### PR DESCRIPTION
### Changelog

* Added the `/presences` command to dynamically set the bot's status, activity type, and activity name from the Discord application at runtime.

### Todos

* At the moment, the bot has no form of persistence for stateful data, so the activity is cleared every time the bot starts up again.
* Identified a problem with the `iterateEnum` helper where it includes the enum values as keys due to the underlying `Object.entries()`. I temporarily circumvent this problem by using `.filter(name => isNaN(Number(name)))` to filter out number keys.
  * `iterateEnum`'s incorrect behavior somehow didn't (visibly) affect `checkPrivilege`, which uses `iterateEnum`, but I may have to look into that.