### PR TITLE
Tweak uwu reaction cooldown

### DIFF
--- a/src/controllers/special/coffee.controller.ts
+++ b/src/controllers/special/coffee.controller.ts
@@ -14,12 +14,18 @@ const log = getLogger(__filename);
 
 const onUwu = new MessageListener("uwu");
 
-onUwu.filter(messageFrom("COFFEE"));
 onUwu.filter(contentMatching(/^uwu$/i));
 onUwu.cooldown.set({
   type: "global",
-  seconds: 600,
+  seconds: 10,
 });
+
+if (uids.COFFEE === undefined) {
+  log.warning("coffee UID not found");
+} else {
+  onUwu.cooldown.setBypass(true, uids.COFFEE);
+}
+
 onUwu.execute(async (message) => {
   await message.react("🤢");
   await message.react("🤮");


### PR DESCRIPTION
## Changelog

* Now reacts to anyone, not just Coffee.
* Global cooldown lowered to 10 seconds.
* Set cooldown bypass for Coffee.

## Todos

`CooldownManager` has been designed to support changing of cooldown specs at runtime, but we currently do not have commands set up to even use its API, so at the moment the only way to change the values is to change source code and restart the bot. Obviously, this is a pain for version control, so this should be looked into ASAP.