### PR TITLE
React w/ L on non-Klee dabs if CD/channel restrict

### DIFF
--- a/src/middleware/filters.middleware.ts
+++ b/src/middleware/filters.middleware.ts
@@ -1,6 +1,6 @@
 import { Events, GuildTextBasedChannel } from "discord.js";
 
-import { ListenerFilter } from "../types/listener.types";
+import { ListenerFilterFunction } from "../types/listener.types";
 import uids from "../utils/uids.utils";
 
 /**
@@ -9,7 +9,7 @@ import uids from "../utils/uids.utils";
  * NOTE: This includes ALL bot users, not just our client's user. The latter
  * should always be ignored anyway as enforced by the event handler dispatcher.
  */
-export const ignoreBots: ListenerFilter<Events.MessageCreate> =
+export const ignoreBots: ListenerFilterFunction<Events.MessageCreate> =
   message => !message.author.bot;
 
 /**
@@ -18,7 +18,7 @@ export const ignoreBots: ListenerFilter<Events.MessageCreate> =
  */
 export function messageFrom(
   ...names: (keyof typeof uids)[]
-): ListenerFilter<Events.MessageCreate> {
+): ListenerFilterFunction<Events.MessageCreate> {
   return message => names.some(name => message.author.id === uids[name]);
 }
 
@@ -27,8 +27,9 @@ export function messageFrom(
  * That is, the predicate should fail on "important" channels such as
  * #announcements as well as central hubs like #general.
  */
-export const channelPollutionAllowed: ListenerFilter<Events.MessageCreate> =
-  message => {
+export const channelPollutionAllowed
+  : ListenerFilterFunction<Events.MessageCreate>
+  = message => {
     const channel = message.channel as GuildTextBasedChannel;
     const channelName = channel.name.toLowerCase();
 
@@ -49,13 +50,13 @@ export const channelPollutionAllowed: ListenerFilter<Events.MessageCreate> =
 
 export function contentMatching(
   pattern: string | RegExp,
-): ListenerFilter<Events.MessageCreate> {
+): ListenerFilterFunction<Events.MessageCreate> {
   return message => !!message.content.match(pattern);
 }
 
 export function randomly(
   successChance: number,
-): ListenerFilter<Events.MessageCreate> {
+): ListenerFilterFunction<Events.MessageCreate> {
   if (successChance < 0 || successChance > 1) {
     throw new Error(
       `successChance must be in range [0, 1] but received ${successChance}`

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -1,8 +1,13 @@
-import { Message, MessageFlags } from "discord.js";
+import { GuildEmoji, Message, MessageFlags } from "discord.js";
+
+import getLogger from "../logger";
+import { formatContext } from "./logging.utils";
+
+const log = getLogger(__filename);
 
 /**
  * Wrapper for the boilerplate of replying to a `Message` with the `@silent`
- * setting and without pinging the author.
+ * setting and without pinging anyone.
  */
 export async function replySilently(message: Message, content: string) {
   await message.reply({
@@ -11,3 +16,31 @@ export async function replySilently(message: Message, content: string) {
     flags: MessageFlags.SuppressNotifications,
   });
 }
+
+class CustomEmojiReacter {
+  private namesToEmojiCache: Record<string, GuildEmoji> = {};
+
+  public react = async (message: Message, emojiName: string): Promise<void> => {
+    let emoji: GuildEmoji;
+    if (emojiName in this.namesToEmojiCache) {
+      emoji = this.namesToEmojiCache[emojiName];
+    } else {
+      const emojiCache = message.guild?.emojis.cache;
+      const maybeEmoji = emojiCache?.find(emoji => emoji.name === emojiName);
+      if (!maybeEmoji) {
+        const context = formatContext(message);
+        log.warning(`${context}: no emoji with name '${emojiName}' found.`);
+        return;
+      }
+      emoji = maybeEmoji;
+      this.namesToEmojiCache[emojiName] = emoji;
+    }
+
+    await message.react(emoji);
+  }
+}
+
+const customEmojiReacter = new CustomEmojiReacter();
+
+export const reactCustomEmoji
+  = customEmojiReacter.react.bind(customEmojiReacter);


### PR DESCRIPTION
**Feature requested by Klee:**

![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/8035b520-b164-438e-9f1f-bf9967a935ff)

The bot now reacts with `:nekocatL:` on dabs that are on cooldown or blocked by channel restrictions if the dabber is not Klee. The normal dab response that occurs with global cooldown is unaffected.

## Internal Changelog

This entailed the addition of a couple features to our `MessageListener` & `CooldownManager` architecture:

* `CooldownManager` now accepts an `onCooldown` callback (within `CooldownSpec`) to run when the listener fires on cooldown.
* The `MessageListener#handleEvent` override now runs `onCooldown` if provided and cooldown is active.