### PR TITLE
Add features deemed "anti-Cxtie"

### DIFF
--- a/src/controllers/special/cxtie.controller.ts
+++ b/src/controllers/special/cxtie.controller.ts
@@ -1,10 +1,15 @@
 import {
   CommandInteractionOptionResolver,
-  SlashCommandBuilder
+  GuildTextBasedChannel,
+  SlashCommandBuilder,
 } from "discord.js";
 
 import getLogger from "../../logger";
-import { messageFrom } from "../../middleware/filters.middleware";
+import {
+  contentMatching,
+  isPollutionImmuneChannel,
+  messageFrom,
+} from "../../middleware/filters.middleware";
 import {
   RoleLevel,
   checkPrivilege,
@@ -111,10 +116,42 @@ onCringeEmoji.execute(async (message) => {
   await reactCustomEmoji(message, NEKO_GUN_EMOJI_NAME);
 });
 
+const onTempyWempy = new MessageListener("tempy-wempy");
+
+onTempyWempy.filter(contentMatching(/tempy wempy/i));
+onTempyWempy.cooldown.set({
+  type: "global",
+  seconds: 60,
+});
+onTempyWempy.execute(async (message) => {
+  const channel = message.channel as GuildTextBasedChannel;
+  let reacted: boolean;
+  if (isPollutionImmuneChannel(channel)) {
+    await message.react("🇸");
+    await message.react("🇹");
+    await message.react("🇴");
+    await message.react("🇵");
+    reacted = true;
+  } else {
+    await replySilently(message, "Stop calling me that.");
+    reacted = false;
+  }
+  log.debug(
+    `${formatContext(message)}: protested being called "tempy wempy" ` +
+    `(${reacted ? "reacted" : "replied"}).`
+  );
+});
+
 const controller: Controller = {
   name: "cxtie",
   commands: [setReactChance],
-  listeners: [onSniffs, onChatRevive, randomReacter, onCringeEmoji],
+  listeners: [
+    onSniffs,
+    onChatRevive,
+    randomReacter,
+    onCringeEmoji,
+    onTempyWempy,
+  ],
 };
 
 export default controller;

--- a/src/controllers/special/cxtie.controller.ts
+++ b/src/controllers/special/cxtie.controller.ts
@@ -101,10 +101,20 @@ setReactChance.execute(async (interaction) => {
   );
 });
 
+const NEKO_GUN_EMOJI_NAME = "kzNekogun";
+
+const onCringeEmoji = new MessageListener("cringe-emoji");
+
+onCringeEmoji.filter(messageFrom("CXTIE"));
+onCringeEmoji.filter(cxtieService.containsCringeEmojis);
+onCringeEmoji.execute(async (message) => {
+  await reactCustomEmoji(message, NEKO_GUN_EMOJI_NAME);
+});
+
 const controller: Controller = {
   name: "cxtie",
   commands: [setReactChance],
-  listeners: [onSniffs, onChatRevive, randomReacter],
+  listeners: [onSniffs, onChatRevive, randomReacter, onCringeEmoji],
 };
 
 export default controller;

--- a/src/middleware/filters.middleware.ts
+++ b/src/middleware/filters.middleware.ts
@@ -23,30 +23,35 @@ export function messageFrom(
 }
 
 /**
+ * Return whether this channel is one of the channels that should be immune to
+ * "pollution".
+ */
+export function isPollutionImmuneChannel(
+  channel: GuildTextBasedChannel,
+): boolean {
+  // Might be best to not annoy the kiddos too much.
+  if (channel.name.indexOf("general") !== -1)
+    return true;
+
+  // Don't pollute important channels.
+  const importantSubstrings = ["introductions", "announcements", "welcome"];
+  if (importantSubstrings.some(s => channel.name.indexOf(s) !== -1))
+    return true;
+
+  // TODO: Maybe also somehow ignore "serious" channels (such as forum posts
+  // tagged with Mental Health).
+
+  return false;
+}
+
+/**
  * Only listen to messages created in a channel where pollution is "acceptable".
  * That is, the predicate should fail on "important" channels such as
  * #announcements as well as central hubs like #general.
  */
 export const channelPollutionAllowed
   : ListenerFilterFunction<Events.MessageCreate>
-  = message => {
-    const channel = message.channel as GuildTextBasedChannel;
-    const channelName = channel.name.toLowerCase();
-
-    // Might be best to not annoy the kiddos too much.
-    if (channelName.indexOf("general") !== -1)
-      return false;
-
-    // Don't pollute important channels.
-    const importantSubstrings = ["introductions", "announcements", "welcome"];
-    if (importantSubstrings.some(s => channelName.indexOf(s) !== -1))
-      return false;
-
-    // TODO: Maybe also somehow ignore "serious" channels (such as forum posts
-    // tagged with Mental Health).
-
-    return true;
-  };
+  = message => !isPollutionImmuneChannel(message.channel as GuildTextBasedChannel);
 
 export function contentMatching(
   pattern: string | RegExp,

--- a/src/services/cxtie.service.ts
+++ b/src/services/cxtie.service.ts
@@ -1,0 +1,9 @@
+export class CxtieService {
+  public static INIT_TIMER_REACT_CHANCE = 0.05;
+  private currentReactChance = CxtieService.INIT_TIMER_REACT_CHANCE;
+
+  public get reactChance(): number { return this.currentReactChance; }
+  public set reactChance(chance: number) { this.currentReactChance = chance; }
+}
+
+export default new CxtieService();

--- a/src/services/cxtie.service.ts
+++ b/src/services/cxtie.service.ts
@@ -1,9 +1,32 @@
+import { Message } from "discord.js";
+import getLogger from "../logger";
+import { formatContext } from "../utils/logging.utils";
+import { parseCustomEmojis } from "../utils/markdown.utils";
+
+const SUP_EMOJI_ID = "1171056612761403413"
+const SLAY_EMOJI_ID = "1176908139896000623";
+
+const log = getLogger(__filename);
+
 export class CxtieService {
   public static INIT_TIMER_REACT_CHANCE = 0.05;
   private currentReactChance = CxtieService.INIT_TIMER_REACT_CHANCE;
 
   public get reactChance(): number { return this.currentReactChance; }
   public set reactChance(chance: number) { this.currentReactChance = chance; }
+
+  public containsCringeEmojis = (message: Message): boolean => {
+    const emojis = parseCustomEmojis(message.content);
+    const containsCringe = emojis.some(e => {
+      const isCringe = e.id === SUP_EMOJI_ID || e.id === SLAY_EMOJI_ID;
+      if (isCringe) {
+        const context = formatContext(message);
+        log.debug(`${context}: detected cringe emoji :${e.name}:.`);
+      }
+      return isCringe;
+    });
+    return containsCringe;
+  }
 }
 
 export default new CxtieService();

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -63,3 +63,19 @@ export function toBulletedList(lines: string[], level: number = 0): string {
   const indent = "  ".repeat(level);
   return lines.map(line => `${indent}* ${line}`).join("\n");
 }
+
+export type CustomEmoji = {
+  name: string;
+  id: string;
+};
+
+export function parseCustomEmojis(content: string): CustomEmoji[] {
+  const CUSTOM_EMOJI_REGEXP = /<:(.+?):(\d+?)>/g;
+  const matches = content.matchAll(CUSTOM_EMOJI_REGEXP);
+  const emojis: CustomEmoji[] = [];
+  for (const match of matches) {
+    const [_, name, id] = match;
+    emojis.push({ name, id });
+  }
+  return emojis;
+}


### PR DESCRIPTION
## Changelog

* Randomly react to Cxtie messages with emojis that mean "hm, timeout?" as a reference to what mods (specifically Taco) do already sometimes.

  ![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/0d220dd4-1d7f-4387-9350-02a7c18b9075)

* React with `kzNekogun` on the cringe "rizz" emojis that Cxtie often sends.

  ![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/797a2c48-bd28-4798-a2ad-0bc842c6b37a)

* Protest messages calling the bot "tempy wempy". Behavior differs between if the channel is "pollution-immune" or not:
  * Reacts with regional indicators to spell out "STOP" if the channel is pollution-immune.
  * Replies with "Stop calling me that" otherwise.