### PR TITLE
Refactor emoji constants

### DIFF
--- a/src/controllers/moderation/profanity.controller.ts
+++ b/src/controllers/moderation/profanity.controller.ts
@@ -7,11 +7,11 @@ import {
 import { Message } from "discord.js";
 import getLogger from "../../logger";
 import { Controller, MessageListener } from "../../types/controller.types";
+import { GUILD_EMOJIS } from "../../utils/emojis.utils";
+import { reactCustomEmoji } from "../../utils/interaction.utils";
 import { formatContext } from "../../utils/logging.utils";
 
 const log = getLogger(__filename);
-
-const NEKO_GUN_EMOJI_NAME = "kzNekogun";
 
 const profanityMatcher = new RegExpMatcher({
   ...englishDataset.build(),
@@ -45,18 +45,12 @@ const onProfanity = new MessageListener("profanity");
 
 onProfanity.filter(checkAndLogProfanityMatches);
 onProfanity.execute(async (message) => {
-  const context = formatContext(message);
-  const emojiCache = message.guild!.emojis.cache;
-  const gunEmoji = emojiCache.find(emoji => emoji.name === NEKO_GUN_EMOJI_NAME);
-  if (!gunEmoji) {
-    log.warning(
-      `${context}: no guild emoji with name '${NEKO_GUN_EMOJI_NAME}' found.`
-    );
-    return false;
+  const success = await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_GUN);
+  if (success) {
+    const context = formatContext(message);
+    log.debug(`${context}: detected profanity, reacted with gun emoji.`);
   }
-  await message.react(gunEmoji);
-  log.debug(`${context}: detected profanity, reacted with gun emoji.`);
-  return true;
+  return success;
 });
 
 const controller: Controller = {

--- a/src/controllers/special/cxtie.controller.ts
+++ b/src/controllers/special/cxtie.controller.ts
@@ -20,6 +20,7 @@ import {
   Controller,
   MessageListener,
 } from "../../types/controller.types";
+import { GUILD_EMOJIS } from "../../utils/emojis.utils";
 import { reactCustomEmoji, replySilently } from "../../utils/interaction.utils";
 import { formatContext } from "../../utils/logging.utils";
 import uids from "../../utils/uids.utils";
@@ -65,14 +66,12 @@ onChatRevive.execute(async (message) => {
   await replySilently(message, "no");
 });
 
-const HMM_EMOJI_NAME = "hmm";
-
 const randomReacter = new MessageListener("anti-cxtie");
 
 randomReacter.filter(messageFrom("CXTIE"));
 randomReacter.filter(_ => Math.random() < cxtieService.reactChance);
 randomReacter.execute(async (message) => {
-  await reactCustomEmoji(message, HMM_EMOJI_NAME);
+  await reactCustomEmoji(message, GUILD_EMOJIS.HMM);
   await message.react("⏲️");
   await message.react("❓");
   log.debug(`${formatContext(message)}: reacted with anti-Cxtie emojis.`);
@@ -106,14 +105,12 @@ setReactChance.execute(async (interaction) => {
   );
 });
 
-const NEKO_GUN_EMOJI_NAME = "kzNekogun";
-
 const onCringeEmoji = new MessageListener("cringe-emoji");
 
 onCringeEmoji.filter(messageFrom("CXTIE"));
 onCringeEmoji.filter(cxtieService.containsCringeEmojis);
 onCringeEmoji.execute(async (message) => {
-  await reactCustomEmoji(message, NEKO_GUN_EMOJI_NAME);
+  await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_GUN);
 });
 
 const onTempyWempy = new MessageListener("tempy-wempy");

--- a/src/controllers/special/klee.controller.ts
+++ b/src/controllers/special/klee.controller.ts
@@ -6,13 +6,12 @@ import {
   ignoreBots,
 } from "../../middleware/filters.middleware";
 import { Controller, MessageListener } from "../../types/controller.types";
+import { GUILD_EMOJIS } from "../../utils/emojis.utils";
 import { reactCustomEmoji, replySilently } from "../../utils/interaction.utils";
 import { formatContext } from "../../utils/logging.utils";
 import uids from "../../utils/uids.utils";
 
 const log = getLogger(__filename);
-
-const NEKO_L_EMOJI_NAME = "nekocatL";
 
 const onDab = new MessageListener("dab");
 
@@ -20,7 +19,7 @@ onDab.cooldown.set({
   type: "global",
   seconds: 600,
   async onCooldown(message) {
-    await reactCustomEmoji(message, NEKO_L_EMOJI_NAME);
+    await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_L);
   },
 });
 
@@ -37,7 +36,7 @@ onDab.filter({
   predicate: (message) =>
     message.author.id === uids.KLEE || channelPollutionAllowed(message),
   onFail: async (message) =>
-    await reactCustomEmoji(message, NEKO_L_EMOJI_NAME)
+    await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_L)
 });
 
 onDab.execute(async (message) => {

--- a/src/controllers/special/wav.controller.ts
+++ b/src/controllers/special/wav.controller.ts
@@ -1,12 +1,11 @@
 import getLogger from "../../logger";
 import { contentMatching } from "../../middleware/filters.middleware";
 import { Controller, MessageListener } from "../../types/controller.types";
+import { GUILD_EMOJIS } from "../../utils/emojis.utils";
 import { reactCustomEmoji } from "../../utils/interaction.utils";
 import uids from "../../utils/uids.utils";
 
 const log = getLogger(__filename);
-
-const NEKO_UWU_EMOJI_NAME = "7482uwucat1";
 
 const onPookie = new MessageListener("pookie");
 
@@ -30,7 +29,7 @@ if (uids.COFFEE === undefined) {
 }
 
 onPookie.execute(async (message) => {
-  await reactCustomEmoji(message, NEKO_UWU_EMOJI_NAME);
+  await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_UWU);
 });
 
 const controller: Controller = {

--- a/src/services/cxtie.service.ts
+++ b/src/services/cxtie.service.ts
@@ -1,12 +1,15 @@
 import { Message } from "discord.js";
-import getLogger from "../logger";
-import { formatContext } from "../utils/logging.utils";
-import { parseCustomEmojis } from "../utils/markdown.utils";
 
-const SUP_EMOJI_ID = "1171056612761403413"
-const SLAY_EMOJI_ID = "1176908139896000623";
+import getLogger from "../logger";
+import { parseCustomEmojis } from "../utils/emojis.utils";
+import { formatContext } from "../utils/logging.utils";
 
 const log = getLogger(__filename);
+
+// NOTE: These emojis are from outside yung kai world so they are not part of
+// our custom emojis mapping.
+const SUP_EMOJI_ID = "1171056612761403413"
+const SLAY_EMOJI_ID = "1176908139896000623";
 
 export class CxtieService {
   public static INIT_TIMER_REACT_CHANCE = 0.05;

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -23,7 +23,7 @@ export type ListenerFilterFunction<Event extends keyof ClientEvents> =
   (...args: ClientEvents[Event]) => Awaitable<boolean>;
 
 export type ListenerFilterFailHandler<Event extends keyof ClientEvents> =
-  (...args: ClientEvents[Event]) => Awaitable<void>;
+  (...args: ClientEvents[Event]) => Awaitable<any>;
 
 export type ListenerFilter<Event extends keyof ClientEvents> = {
   predicate: ListenerFilterFunction<Event>,

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -1,0 +1,23 @@
+export type CustomEmoji = {
+  name: string;
+  id: string;
+};
+
+export function parseCustomEmojis(content: string): CustomEmoji[] {
+  const CUSTOM_EMOJI_REGEXP = /<:(.+?):(\d+?)>/g;
+  const matches = content.matchAll(CUSTOM_EMOJI_REGEXP);
+  const emojis: CustomEmoji[] = [];
+  for (const match of matches) {
+    const [_, name, id] = match;
+    emojis.push({ name, id });
+  }
+  return emojis;
+}
+
+/** Partial database of yung kai world's custom emoji names. */
+export const GUILD_EMOJIS = {
+  NEKO_GUN: "kzNekogun",
+  HMM: "hmm",
+  NEKO_L: "nekocatL",
+  NEKO_UWU: "7482uwucat1",
+};

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -63,19 +63,3 @@ export function toBulletedList(lines: string[], level: number = 0): string {
   const indent = "  ".repeat(level);
   return lines.map(line => `${indent}* ${line}`).join("\n");
 }
-
-export type CustomEmoji = {
-  name: string;
-  id: string;
-};
-
-export function parseCustomEmojis(content: string): CustomEmoji[] {
-  const CUSTOM_EMOJI_REGEXP = /<:(.+?):(\d+?)>/g;
-  const matches = content.matchAll(CUSTOM_EMOJI_REGEXP);
-  const emojis: CustomEmoji[] = [];
-  for (const match of matches) {
-    const [_, name, id] = match;
-    emojis.push({ name, id });
-  }
-  return emojis;
-}


### PR DESCRIPTION
## Internal Changelog

* [Move emoji-related utilities to new utils module.](https://github.com/vinlin24/yungkaiworldbot/commit/5a5320ebfd73323b4dec3a23728dbc2973bbbe3c) Also add a new `GUILD_EMOJIS` mapping as a partial database of the names of custom emojis in yung kai world.
* [Make reactCustomEmoji return success boolean.](https://github.com/vinlin24/yungkaiworldbot/commit/dd6ef32f6c13be71edf42f5b3e7b48dcec3c80b5) This would be important to `execute` functions that need to know if the operation succeeded such that they can return their own success boolean.
* [Use the new `GUILD_EMOJIS` mapping instead of module constants for custom emoji names.](https://github.com/vinlin24/yungkaiworldbot/commit/0901b340ec37881ab625f6818aacb178b25c5c21)