### PR TITLE
Stop showing -1 ping

### DIFF
--- a/src/controllers/dev/ping.controller.ts
+++ b/src/controllers/dev/ping.controller.ts
@@ -33,13 +33,17 @@ const pingCommand = new Command(new SlashCommandBuilder()
 pingCommand.execute(async (interaction) => {
   let text = "Hello there!";
 
+  const latency = interaction.client.ws.ping;
   // NOTE: For some reason, this seems to be -1 for a while right after bot
   // startup. Supposedly this is because the client has not sent its first
   // heartbeat yet.
-  const latency = interaction.client.ws.ping;
-  text += `\n* Latency: **${latency}** ms`;
-  if (latency == 69) { // Easter egg.
-    text += " (nice)";
+  if (latency === -1) {
+    text += `\n* Latency: (still being calculated...)`
+  } else {
+    text += `\n* Latency: **${latency}** ms`;
+    if (latency == 69) { // Easter egg.
+      text += " (nice)";
+    }
   }
 
   const branchName = getCurrentBranchName();


### PR DESCRIPTION
This is in reference to the `/ping` command.

Use a placeholder message instead saying it's currently being calculated. Comparison:

![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/f0179099-e4c0-48bd-a1c0-6c219dd2fc81)

![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/4f8cad58-a251-4b6e-9858-6eff14b3aa58)
