### PR TITLE
Add broadcast option in Command constructor

### DIFF
--- a/src/controllers/dev/cooldowns.controller.ts
+++ b/src/controllers/dev/cooldowns.controller.ts
@@ -19,15 +19,12 @@ const listCooldowns = new Command(new SlashCommandBuilder()
   .setDescription(
     "List current cooldowns associated with message creation events."
   )
-  .addBooleanOption(input => input
-    .setName("broadcast")
-    .setDescription("Whether to respond publicly instead of ephemerally.")
-  )
   .addStringOption(input => input
     .setName("listener")
     .setDescription("ID of the listener (omit to list ALL cooldowns).")
     .setAutocomplete(true)
-  )
+  ),
+  { broadcastOption: true },
 );
 
 listCooldowns.check(checkPrivilege(RoleLevel.DEV)); // TEMP.

--- a/src/controllers/dev/ping.controller.ts
+++ b/src/controllers/dev/ping.controller.ts
@@ -23,11 +23,8 @@ function getCurrentBranchName(): string | null {
 
 const pingCommand = new Command(new SlashCommandBuilder()
   .setName("ping")
-  .setDescription("Basic sanity check command.")
-  .addBooleanOption(option => option
-    .setName("broadcast")
-    .setDescription("Whether to respond publicly instead of ephemerally")
-  )
+  .setDescription("Basic sanity check command."),
+  { broadcastOption: true },
 );
 
 pingCommand.execute(async (interaction) => {

--- a/src/types/command.types.ts
+++ b/src/types/command.types.ts
@@ -35,12 +35,27 @@ export type CommandCheck = {
   onError?: CommandCheckErrorHandler;
 };
 
+export type CommandOptions = {
+  /** Whether to insert a broadcast flag in the options for this command. */
+  broadcastOption: boolean,
+};
+
 export class Command {
   private checks: CommandCheck[] = [];
   private callback: CommandExecuteFunction | null = null;
   private errorHandler: CommandErrorHandler | null = null;
   private autocompleteHandler: CommandAutocompleteHandler | null = null;
-  constructor(private slashCommandData: Partial<SlashCommandBuilder>) { }
+  constructor(
+    private slashCommandData: Partial<SlashCommandBuilder>,
+    private options?: CommandOptions,
+  ) {
+    if (this.options?.broadcastOption) {
+      this.slashCommandData.addBooleanOption?.(input => input
+        .setName("broadcast")
+        .setDescription("Whether to respond publicly instead of ephemerally")
+      );
+    }
+  }
 
   public get commandName(): string {
     return this.slashCommandData.name!;


### PR DESCRIPTION
Kind of trivial for just the `broadcast` option at the moment, but `CommandOptions` may be expanded upon in the future. Also, this helps keep the code DRY by specifying potentially repeated option definitions in one place.