### PR TITLE
Update cooldowns at runtime with commands

### DIFF
--- a/src/controllers/dev/cooldowns.controller.ts
+++ b/src/controllers/dev/cooldowns.controller.ts
@@ -1,9 +1,14 @@
 import {
+  AutocompleteInteraction,
+  Collection,
   CommandInteractionOptionResolver,
+  GuildMember,
+  Role,
   SlashCommandBuilder,
 } from "discord.js";
 
 import { BotClient } from "../../client";
+import { CooldownSpec } from "../../middleware/cooldown.middleware";
 import {
   RoleLevel,
   checkPrivilege,
@@ -13,6 +18,32 @@ import {
   Controller,
   MessageListener,
 } from "../../types/controller.types";
+import { formatHoursMinsSeconds } from "../../utils/dates.utils";
+import { getAllMembers } from "../../utils/iteration.utils";
+import { toBulletedList } from "../../utils/markdown.utils";
+
+/**
+ * Return a partial copy of the client's listener spec mapping with only the
+ * listeners that are instances of `MessageListener`.
+ */
+function filterListenerMap(client: BotClient)
+  : Collection<string, MessageListener> {
+  return client.listenerSpecs
+    .filter(listener => listener instanceof MessageListener)
+    .mapValues(listener => listener as MessageListener);
+}
+
+async function listenerIdAutocomplete(interaction: AutocompleteInteraction) {
+  const focusedValue = interaction.options.getFocused();
+
+  const listeners = filterListenerMap(interaction.client as BotClient);
+  const listenersWithCD = listeners.filter(l => l.cooldown.type !== "disabled");
+  const choiceObjs = listenersWithCD
+    .filter(({ id }) => id.startsWith(focusedValue))
+    .map(({ id }) => ({ name: id, value: id }));
+
+  await interaction.respond(choiceObjs);
+}
 
 const listCooldowns = new Command(new SlashCommandBuilder()
   .setName("cooldowns")
@@ -28,15 +59,13 @@ const listCooldowns = new Command(new SlashCommandBuilder()
 );
 
 listCooldowns.check(checkPrivilege(RoleLevel.DEV)); // TEMP.
+listCooldowns.autocomplete(listenerIdAutocomplete);
 listCooldowns.execute(async (interaction) => {
   const options = interaction.options as CommandInteractionOptionResolver;
   const broadcast = options.getBoolean("broadcast");
   const listenerId = options.getString("listener");
 
-  const client = interaction.client as BotClient;
-  const listenerMap = client.listenerSpecs
-    .filter(listener => listener instanceof MessageListener)
-    .mapValues(listener => listener as MessageListener);
+  const listenerMap = filterListenerMap(interaction.client as BotClient);
 
   // Caller provided an ID but it's invalid.
   if (listenerId && !listenerMap.get(listenerId)) {
@@ -78,25 +107,202 @@ listCooldowns.execute(async (interaction) => {
   });
 });
 
-listCooldowns.autocomplete(async (interaction) => {
-  const focusedValue = interaction.options.getFocused();
+const setCooldown = new Command(new SlashCommandBuilder()
+  .setName(`set-listener-cooldown`)
+  .setDescription("Set the cooldown spec for the a message creation listener.")
+  .addStringOption(input => input
+    .setName("listener")
+    .setDescription("Listener ID.")
+    .setRequired(true)
+    .setAutocomplete(true)
+  )
+  .addStringOption(input => input
+    .setName("type")
+    .setDescription("Cooldown type.")
+    .setRequired(true)
+    .addChoices(
+      { name: "Global", value: "global" },
+      { name: "Per-user", value: "user" },
+      { name: "Disabled", value: "disabled" },
+    )
+  )
+  .addNumberOption(input => input
+    .setName("seconds")
+    .setDescription("Default duration of cooldown (in seconds).")
+    .setMinValue(0)
+  ),
+  { broadcastOption: true },
+);
 
-  const listeners = (interaction.client as BotClient).listenerSpecs;
-  const listenersWithCD = listeners
-    .filter(l => l instanceof MessageListener)
-    .map(l => l as MessageListener)
-    .filter(l => l.cooldown.type !== "disabled");
-  const choiceObjs = listenersWithCD
-    .map(l => l.id)
-    .filter(id => id.startsWith(focusedValue))
-    .map(id => ({ name: id, value: id }));
+setCooldown.check(checkPrivilege(RoleLevel.DEV));
+setCooldown.autocomplete(listenerIdAutocomplete);
+setCooldown.execute(async (interaction) => {
+  const options = interaction.options as CommandInteractionOptionResolver;
+  const broadcast = options.getBoolean("options") ?? false;
+  const listenerId = options.getString("listener", true);
 
-  await interaction.respond(choiceObjs);
+  const listenerMap = filterListenerMap(interaction.client as BotClient);
+  const listener = listenerMap.get(listenerId);
+  if (!listener) {
+    await interaction.reply({
+      content: `There's no listener with cooldown with ID=\`${listenerId}\`!`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const type = options.getString("type", true) as CooldownSpec["type"];
+
+  if (type === "disabled") {
+    listener.cooldown.update({ type: "disabled" });
+    await interaction.reply({
+      content: `Disabled cooldown for **${listenerId}**!`,
+      ephemeral: !broadcast,
+    });
+    return;
+  }
+
+  const seconds = options.getNumber("seconds");
+  if (seconds === null) {
+    await interaction.reply({
+      content: "Specify a value for the default cooldown duration!",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (type === "global") {
+    listener.cooldown.update({ type: "global", seconds });
+  } else if (type === "user") {
+    listener.cooldown.update({ type: "user", defaultSeconds: seconds });
+  }
+
+  const response = `Updated **${listenerId}** cooldown spec:\n` +
+    toBulletedList([
+      `Type: \`${type}\``,
+      `Default duration: ${formatHoursMinsSeconds(seconds)}`,
+    ]);
+  await interaction.reply({ content: response, ephemeral: !broadcast });
+});
+
+const overrideCooldown = new Command(new SlashCommandBuilder()
+  .setName(`override-listener-cooldown`)
+  .setDescription(`Set cooldown overrides for a message creation listener.`)
+  .addStringOption(input => input
+    .setName("listener")
+    .setDescription("Listener ID.")
+    .setRequired(true)
+    .setAutocomplete(true)
+  )
+  .addMentionableOption(input => input
+    .setName("mentionable")
+    // TODO: supporting roles mean that the underlying list of members with
+    // overrides can easily explode in size, likely making the current
+    // implementation of /cooldowns (which returns an unpaginated text
+    // response) error out from exceeded message length limit.
+    .setDescription("Member or role to set overrides for.")
+    .setRequired(true)
+  )
+  .addNumberOption(input => input
+    .setName("duration")
+    .setDescription(
+      "User-specific cooldown duration override " +
+      "(in seconds) (USER type cooldown only)."
+    )
+    .setMinValue(0)
+  )
+  .addBooleanOption(input => input
+    .setName("bypass")
+    .setDescription("Allow this user to bypass cooldown duration.")
+  ),
+  { broadcastOption: true },
+);
+
+overrideCooldown.check(checkPrivilege(RoleLevel.DEV));
+overrideCooldown.autocomplete(listenerIdAutocomplete);
+overrideCooldown.execute(async (interaction) => {
+  const options = interaction.options as CommandInteractionOptionResolver;
+  const broadcast = options.getBoolean("broadcast") ?? false;
+  const listenerId = options.getString("listener", true);
+
+  const listenerMap = filterListenerMap(interaction.client as BotClient);
+  const listener = listenerMap.get(listenerId);
+  if (!listener) {
+    await interaction.reply({
+      content: `There's no listener with cooldown with ID=\`${listenerId}\`!`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const { cooldown } = listener;
+
+  if (cooldown.type === "disabled") {
+    await interaction.reply({
+      content: `Cooldown for **${listenerId}** is currently disabled!`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const mentionable
+    = options.getMentionable("mentionable", true) as GuildMember | Role;
+  const members = getAllMembers(mentionable);
+
+  const duration = options.getNumber("duration");
+  const bypass = options.getBoolean("bypass");
+
+  if (duration !== null && bypass !== null) {
+    await interaction.reply({
+      content: "Provide a duration or bypass value but not both!",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (duration !== null) {
+    if (cooldown.type !== "user") {
+      await interaction.reply({
+        content: "`duration` is only compatible with `user` cooldown type.",
+        ephemeral: true,
+      });
+      return;
+    }
+    for (const member of members)
+      cooldown.setDuration(duration, member.id);
+    await interaction.reply({
+      content:
+        `Set **${listenerId}** cooldown duration override for ` +
+        `${mentionable}: ${formatHoursMinsSeconds(duration)}.`,
+      ephemeral: !broadcast,
+      // TODO: Maybe make a replySilently overload for interactions.
+      allowedMentions: { parse: [] },
+    });
+    return;
+  }
+
+  if (bypass !== null) {
+    for (const member of members)
+      cooldown.setBypass(bypass, member.id);
+    await interaction.reply({
+      content:
+        `${bypass ? "Enabled" : "Disabled"} **${listenerId}** bypass ` +
+        `for ${mentionable}.`,
+      ephemeral: !broadcast,
+      allowedMentions: { parse: [] },
+    });
+    return;
+  }
+
+  await interaction.reply({
+    content: "Missing argument(s)!",
+    ephemeral: true,
+  });
 });
 
 const controller = new Controller({
   name: "cooldowns",
-  commands: [listCooldowns],
+  commands: [listCooldowns, setCooldown, overrideCooldown],
   listeners: [],
 });
 

--- a/src/controllers/dev/cooldowns.controller.ts
+++ b/src/controllers/dev/cooldowns.controller.ts
@@ -94,10 +94,10 @@ listCooldowns.autocomplete(async (interaction) => {
   await interaction.respond(choiceObjs);
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "cooldowns",
   commands: [listCooldowns],
   listeners: [],
-};
+});
 
 export default controller;

--- a/src/controllers/dev/ping.controller.ts
+++ b/src/controllers/dev/ping.controller.ts
@@ -53,10 +53,10 @@ pingCommand.execute(async (interaction) => {
   await interaction.reply({ content: text, ephemeral: !broadcast });
 });
 
-const spec: Controller = {
+const spec = new Controller({
   name: "ping",
   commands: [pingCommand],
   listeners: [],
-};
+});
 
 export default spec;

--- a/src/controllers/dev/presence.controller.ts
+++ b/src/controllers/dev/presence.controller.ts
@@ -112,10 +112,10 @@ changePresence.execute(async (interaction) => {
   await interaction.reply("👍");
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "presence",
   commands: [changePresence],
   listeners: [],
-};
+});
 
 export default controller;

--- a/src/controllers/dev/shutdown.controller.ts
+++ b/src/controllers/dev/shutdown.controller.ts
@@ -21,10 +21,10 @@ shutdownCommand.execute(async (interaction) => {
   log.info(`${context}: terminated bot runtime.`);
 });
 
-const spec: Controller = {
+const spec = new Controller({
   name: "shutdown",
   commands: [shutdownCommand],
   listeners: [],
-};
+});
 
 export default spec;

--- a/src/controllers/moderation/profanity.controller.ts
+++ b/src/controllers/moderation/profanity.controller.ts
@@ -53,10 +53,10 @@ onProfanity.execute(async (message) => {
   return success;
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "profanity",
   commands: [],
   listeners: [onProfanity],
-};
+});
 
 export default controller;

--- a/src/controllers/moderation/wave.controller.ts
+++ b/src/controllers/moderation/wave.controller.ts
@@ -28,10 +28,10 @@ onIntroduction.execute(async (message) => {
   log.info(`${context}: waved at user's introduction.`);
 });
 
-const spec: Controller = {
+const spec = new Controller({
   name: "wave",
   commands: [],
   listeners: [onIntroduction],
-};
+});
 
 export default spec;

--- a/src/controllers/special/coffee.controller.ts
+++ b/src/controllers/special/coffee.controller.ts
@@ -97,10 +97,10 @@ lofiReacter.execute(async (message) => {
   log.debug(`${formatContext(message)}: reacted with LOFI.`);
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "coffee",
   commands: [],
   listeners: [onUwu, onUff, onCrazy, lofiReacter],
-};
+}).withCooldownCommands();
 
 export default controller;

--- a/src/controllers/special/coffee.controller.ts
+++ b/src/controllers/special/coffee.controller.ts
@@ -101,6 +101,6 @@ const controller = new Controller({
   name: "coffee",
   commands: [],
   listeners: [onUwu, onUff, onCrazy, lofiReacter],
-}).withCooldownCommands();
+});
 
 export default controller;

--- a/src/controllers/special/cxtie.controller.ts
+++ b/src/controllers/special/cxtie.controller.ts
@@ -149,6 +149,6 @@ const controller = new Controller({
     onCringeEmoji,
     onTempyWempy,
   ],
-}).withCooldownCommands();
+});
 
 export default controller;

--- a/src/controllers/special/cxtie.controller.ts
+++ b/src/controllers/special/cxtie.controller.ts
@@ -139,7 +139,7 @@ onTempyWempy.execute(async (message) => {
   );
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "cxtie",
   commands: [setReactChance],
   listeners: [
@@ -149,6 +149,6 @@ const controller: Controller = {
     onCringeEmoji,
     onTempyWempy,
   ],
-};
+}).withCooldownCommands();
 
 export default controller;

--- a/src/controllers/special/deez.controller.ts
+++ b/src/controllers/special/deez.controller.ts
@@ -26,6 +26,6 @@ const controller = new Controller({
   name: "deez",
   commands: [],
   listeners: [onDeez],
-}).withCooldownCommands();
+});
 
 export default controller;

--- a/src/controllers/special/deez.controller.ts
+++ b/src/controllers/special/deez.controller.ts
@@ -1,5 +1,8 @@
 import getLogger from "../../logger";
-import { channelPollutionAllowed, contentMatching } from "../../middleware/filters.middleware";
+import {
+  channelPollutionAllowed,
+  contentMatching,
+} from "../../middleware/filters.middleware";
 import { Controller, MessageListener } from "../../types/controller.types";
 import { replySilently } from "../../utils/interaction.utils";
 import { formatContext } from "../../utils/logging.utils";
@@ -19,10 +22,10 @@ onDeez.execute(async (message) => {
   log.debug(`${formatContext(message)}: replied with deez.`);
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "deez",
   commands: [],
   listeners: [onDeez],
-};
+}).withCooldownCommands();
 
 export default controller;

--- a/src/controllers/special/klee.controller.ts
+++ b/src/controllers/special/klee.controller.ts
@@ -48,6 +48,6 @@ const controller = new Controller({
   name: "klee",
   commands: [],
   listeners: [onDab],
-}).withCooldownCommands();
+});
 
 export default controller;

--- a/src/controllers/special/klee.controller.ts
+++ b/src/controllers/special/klee.controller.ts
@@ -44,10 +44,10 @@ onDab.execute(async (message) => {
   log.debug(`${formatContext(message)}: dabbed back.`);
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "klee",
   commands: [],
   listeners: [onDab],
-};
+}).withCooldownCommands();
 
 export default controller;

--- a/src/controllers/special/luke.controller.ts
+++ b/src/controllers/special/luke.controller.ts
@@ -73,6 +73,6 @@ const spec = new Controller({
   name: "luke",
   commands: [setMeowChance],
   listeners: [dadJoker, randomMeower],
-}).withCooldownCommands();
+});
 
 export default spec;

--- a/src/controllers/special/luke.controller.ts
+++ b/src/controllers/special/luke.controller.ts
@@ -69,10 +69,10 @@ setMeowChance.execute(async (interaction) => {
   );
 })
 
-const spec: Controller = {
+const spec = new Controller({
   name: "luke",
   commands: [setMeowChance],
   listeners: [dadJoker, randomMeower],
-};
+}).withCooldownCommands();
 
 export default spec;

--- a/src/controllers/special/misc.controller.ts
+++ b/src/controllers/special/misc.controller.ts
@@ -25,10 +25,10 @@ onMwah.cooldown.set({
 });
 onMwah.execute(replySilentlyWith("mwah"));
 
-const controller: Controller = {
+const controller = new Controller({
   name: "misc",
   commands: [],
   listeners: [onGulp, onMwah],
-};
+}).withCooldownCommands();
 
 export default controller;

--- a/src/controllers/special/misc.controller.ts
+++ b/src/controllers/special/misc.controller.ts
@@ -29,6 +29,6 @@ const controller = new Controller({
   name: "misc",
   commands: [],
   listeners: [onGulp, onMwah],
-}).withCooldownCommands();
+});
 
 export default controller;

--- a/src/controllers/special/taco.controller.ts
+++ b/src/controllers/special/taco.controller.ts
@@ -32,10 +32,10 @@ onAppreciatedChar.execute(async (message) => {
   return true;
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "taco",
   commands: [],
   listeners: [onAppreciatedChar],
-};
+});
 
 export default controller;

--- a/src/controllers/special/wav.controller.ts
+++ b/src/controllers/special/wav.controller.ts
@@ -32,10 +32,10 @@ onPookie.execute(async (message) => {
   await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_UWU);
 });
 
-const controller: Controller = {
+const controller = new Controller({
   name: "wav",
   commands: [],
   listeners: [onPookie],
-};
+}).withCooldownCommands();
 
 export default controller;

--- a/src/controllers/special/wav.controller.ts
+++ b/src/controllers/special/wav.controller.ts
@@ -36,6 +36,6 @@ const controller = new Controller({
   name: "wav",
   commands: [],
   listeners: [onPookie],
-}).withCooldownCommands();
+});
 
 export default controller;

--- a/src/middleware/cooldown.middleware.ts
+++ b/src/middleware/cooldown.middleware.ts
@@ -1,7 +1,9 @@
 import {
   Awaitable,
   CommandInteractionOptionResolver,
+  GuildMember,
   Message,
+  Role,
   SlashCommandBuilder,
 } from "discord.js";
 import lodash from "lodash";
@@ -9,6 +11,7 @@ import lodash from "lodash";
 import getLogger from "../logger";
 import { Command } from "../types/command.types";
 import { addDateSeconds, formatHoursMinsSeconds } from "../utils/dates.utils";
+import { getAllMembers } from "../utils/iteration.utils";
 import {
   joinUserMentions,
   toBulletedList,
@@ -161,6 +164,7 @@ export class CooldownManager {
 
     if (bypass) {
       this.setUserDuration(0, userId);
+      this.userExpirations.delete(userId); // Invalidate current expiration.
       return;
     }
 
@@ -348,6 +352,105 @@ export class CooldownManager {
           `Default duration: ${formatHoursMinsSeconds(seconds)}`,
         ]);
       await interaction.reply({ content: response, ephemeral: !broadcast });
+    });
+
+    return command;
+  };
+
+  public getCooldownOverriderCommand = (listenerId: string): Command => {
+    const command = new Command(new SlashCommandBuilder()
+      .setName(`override-${listenerId}-cooldown`)
+      .setDescription(`Set cooldown duration overrides for ${listenerId}.`)
+      .addMentionableOption(input => input
+        .setName("mentionable")
+        // TODO: supporting roles mean that the underlying list of members with
+        // overrides can easily explode in size, likely making the current
+        // implementation of /cooldowns (which returns an unpaginated text
+        // response) error out from exceeded message length limit.
+        .setDescription("Member or role to set overrides for.")
+        .setRequired(true)
+      )
+      .addNumberOption(input => input
+        .setName("duration")
+        .setDescription(
+          "User-specific cooldown duration override " +
+          "(in seconds) (USER type cooldown only)."
+        )
+        .setMinValue(0)
+      )
+      .addBooleanOption(input => input
+        .setName("bypass")
+        .setDescription("Allow this user to bypass cooldown duration.")
+      ),
+      { broadcastOption: true },
+    );
+
+    command.check(checkPrivilege(RoleLevel.DEV));
+    command.execute(async (interaction) => {
+      const options = interaction.options as CommandInteractionOptionResolver;
+      const broadcast = options.getBoolean("broadcast") ?? false;
+
+      if (this.spec.type === "disabled") {
+        await interaction.reply({
+          content: `Cooldown for **${listenerId}** is currently disabled!`,
+          ephemeral: true,
+        });
+        return;
+      }
+
+      const mentionable
+        = options.getMentionable("mentionable", true) as GuildMember | Role;
+      const members = getAllMembers(mentionable);
+
+      const duration = options.getNumber("duration");
+      const bypass = options.getBoolean("bypass");
+
+      if (duration !== null && bypass !== null) {
+        await interaction.reply({
+          content: "Provide a duration or bypass value but not both!",
+          ephemeral: true,
+        });
+        return;
+      }
+
+      if (duration !== null) {
+        if (this.spec.type !== "user") {
+          await interaction.reply({
+            content: "`duration` is only compatible with `user` cooldown type.",
+            ephemeral: true,
+          });
+          return;
+        }
+        for (const member of members)
+          this.setDuration(duration, member.id);
+        await interaction.reply({
+          content:
+            `Set **${listenerId}** cooldown duration override for ` +
+            `${mentionable}: ${formatHoursMinsSeconds(duration)}.`,
+          ephemeral: !broadcast,
+          // TODO: Maybe make a replySilently overload for interactions.
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
+      if (bypass !== null) {
+        for (const member of members)
+          this.setBypass(bypass, member.id);
+        await interaction.reply({
+          content:
+            `${bypass ? "Enabled" : "Disabled"} **${listenerId}** bypass ` +
+            `for ${mentionable}.`,
+          ephemeral: !broadcast,
+          allowedMentions: { parse: [] },
+        });
+        return;
+      }
+
+      await interaction.reply({
+        content: "Missing argument(s)!",
+        ephemeral: true,
+      });
     });
 
     return command;

--- a/src/types/controller.types.ts
+++ b/src/types/controller.types.ts
@@ -1,3 +1,5 @@
+
+import { filterMessageListeners } from "../utils/iteration.utils";
 import { Command } from "./command.types";
 import { Listener } from "./listener.types";
 
@@ -7,8 +9,34 @@ export * from "./listener.types";
 // TODO: .name isn't used for anything at the moment. It may also be useful
 // to have commands and listeners store a reference back to the controller for
 // convenient lookup purposes.
-export type Controller = {
+export type ControllerOptions = {
   name: string;
   commands: readonly Command[];
   listeners: readonly Listener<any>[];
 };
+
+export class Controller {
+  public readonly name: string;
+  public readonly commands: Command[];
+  public readonly listeners: Listener<any>[];
+
+  constructor(options: ControllerOptions) {
+    this.name = options.name
+    this.commands = [...options.commands];
+    this.listeners = [...options.listeners];
+  }
+
+  /**
+   * Automatically generate setter and override commands for the
+   * `MessageListener`s currently tracked.
+   */
+  public withCooldownCommands = (): this => {
+    const messageListeners = filterMessageListeners(this.listeners);
+    for (const listener of messageListeners) {
+      const setterCommand = listener.getCooldownSetter();
+      const overriderCommand = listener.getCooldownOverrider();
+      this.commands.push(setterCommand, overriderCommand);
+    }
+    return this;
+  };
+}

--- a/src/types/controller.types.ts
+++ b/src/types/controller.types.ts
@@ -1,5 +1,4 @@
 
-import { filterMessageListeners } from "../utils/iteration.utils";
 import { Command } from "./command.types";
 import { Listener } from "./listener.types";
 
@@ -25,18 +24,4 @@ export class Controller {
     this.commands = [...options.commands];
     this.listeners = [...options.listeners];
   }
-
-  /**
-   * Automatically generate setter and override commands for the
-   * `MessageListener`s currently tracked.
-   */
-  public withCooldownCommands = (): this => {
-    const messageListeners = filterMessageListeners(this.listeners);
-    for (const listener of messageListeners) {
-      const setterCommand = listener.getCooldownSetter();
-      const overriderCommand = listener.getCooldownOverrider();
-      this.commands.push(setterCommand, overriderCommand);
-    }
-    return this;
-  };
 }

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -10,7 +10,6 @@ import { BotClient } from "../client";
 import getLogger from "../logger";
 import { CooldownManager } from "../middleware/cooldown.middleware";
 import { formatContext } from "../utils/logging.utils";
-import { Command } from "./command.types";
 
 const log = getLogger(__filename);
 
@@ -231,13 +230,5 @@ export class MessageListener extends Listener<Events.MessageCreate> {
     if (!success) return;
 
     this.cooldown.refresh(message);
-  }
-
-  public getCooldownSetter = (): Command => {
-    return this.cooldown.getCooldownSetterCommand(this.id);
-  }
-
-  public getCooldownOverrider = (): Command => {
-    return this.cooldown.getCooldownOverriderCommand(this.id);
   }
 }

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -236,4 +236,8 @@ export class MessageListener extends Listener<Events.MessageCreate> {
   public getCooldownSetter = (): Command => {
     return this.cooldown.getCooldownSetterCommand(this.id);
   }
+
+  public getCooldownOverrider = (): Command => {
+    return this.cooldown.getCooldownOverriderCommand(this.id);
+  }
 }

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -10,6 +10,7 @@ import { BotClient } from "../client";
 import getLogger from "../logger";
 import { CooldownManager } from "../middleware/cooldown.middleware";
 import { formatContext } from "../utils/logging.utils";
+import { Command } from "./command.types";
 
 const log = getLogger(__filename);
 
@@ -230,5 +231,9 @@ export class MessageListener extends Listener<Events.MessageCreate> {
     if (!success) return;
 
     this.cooldown.refresh(message);
+  }
+
+  public getCooldownSetter = (): Command => {
+    return this.cooldown.getCooldownSetterCommand(this.id);
   }
 }

--- a/src/utils/iteration.utils.ts
+++ b/src/utils/iteration.utils.ts
@@ -52,9 +52,9 @@ export function getAllMembers(mentionable: GuildMember | Role): GuildMember[] {
  * Return just the `MessageListener` instances within an array of `Listener`s.
  */
 export function filterMessageListeners(
-  listeners: readonly Listener<any>[],
+  listeners: Iterable<Listener<any>>,
 ): MessageListener[] {
-  return listeners
+  return Array.from(listeners)
     .filter(listener => listener instanceof MessageListener)
     .map(listener => listener as MessageListener);
 }

--- a/src/utils/iteration.utils.ts
+++ b/src/utils/iteration.utils.ts
@@ -1,4 +1,5 @@
 import { GuildMember, Role } from "discord.js";
+import { Listener, MessageListener } from "../types/listener.types";
 
 /**
  * Wrapper of `Object.entries(enumerable)` that preserves the key type of
@@ -45,4 +46,15 @@ export function zip<T, U>(array1: T[], array2: U[]): [T, U][] {
 export function getAllMembers(mentionable: GuildMember | Role): GuildMember[] {
   if (mentionable instanceof GuildMember) return [mentionable];
   return Array.from(mentionable.members.values());
+}
+
+/**
+ * Return just the `MessageListener` instances within an array of `Listener`s.
+ */
+export function filterMessageListeners(
+  listeners: readonly Listener<any>[],
+): MessageListener[] {
+  return listeners
+    .filter(listener => listener instanceof MessageListener)
+    .map(listener => listener as MessageListener);
 }

--- a/src/utils/iteration.utils.ts
+++ b/src/utils/iteration.utils.ts
@@ -1,3 +1,5 @@
+import { GuildMember, Role } from "discord.js";
+
 /**
  * Wrapper of `Object.entries(enumerable)` that preserves the key type of
  * `enumerable`. This gets around the problem where TypeScript always assumes
@@ -35,4 +37,12 @@ export function iterateEnum<T extends {}>(enumerable: T)
 export function zip<T, U>(array1: T[], array2: U[]): [T, U][] {
   const length = Math.min(array1.length, array2.length);
   return Array.from({ length }, (_, index) => [array1[index], array2[index]]);
+}
+
+/**
+ * Resolve a mentionable into an array of member objects.
+ */
+export function getAllMembers(mentionable: GuildMember | Role): GuildMember[] {
+  if (mentionable instanceof GuildMember) return [mentionable];
+  return Array.from(mentionable.members.values());
 }


### PR DESCRIPTION
Closes #6.

## Changelog

* Introduced 2 new (dev-level) commands:
  * `/set-listener-cooldown` to change the cooldown spec for message creation listeners. Internally, this serves as the frontend for `CooldownManager#update` (the partial version of `CooldownManager#set`, which does a *complete* change of the spec object and is more suitable at creation time only).
  * `/override-listener-cooldown` to update user overrides for the current cooldown. Internally, this serves as the frontend for `CooldownManager#setBypass` and `CooldownManager#setDuration`.
* Most of the files changed in this PR are due to the conversion of `Controller` from an object `type` to a full-fledged `class`. This was actually done to enable the changes in 0fcb77a15ab206bf1d4dd8c2611d4fddcbf231c5. It turns out that approach did not scale and was replaced with 7824fc38e3e949b7bda5f381832ff7a52b9532b4, effectively reverting the need for it to be a class. However, I think making it a class makes it more future-proof as we may extend it with methods for real at some later point, so we might as well keep this change.

## Todos

* `/override-listener-cooldown` supports a mentionable option. How `Role`s are handled is that they're resolved to a full array of `GuildMember`s since `CooldownManager` only knows how to work with individual members at the moment. The problem with this is that `/cooldowns` responds with an unpaginated text message, and since roles can easily explode in the number of members affected, this can easily cause `/cooldowns` to exceed the message length limit. Two possible solutions are:
  * Break up messages to use pagination (ideally in general, not just for `/cooldowns`).
  * Refactor `CooldownManager` to work with mentionables instead of just members.