### PR TITLE
Add /countdown for counting down from a duration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "dotenv": "^16.3.1",
         "lodash": "^4.17.21",
         "obscenity": "^0.1.4",
+        "parse-duration": "^1.1.0",
         "winston": "^3.11.0",
         "winston-daily-rotate-file": "^4.7.1"
       },
@@ -539,6 +540,11 @@
       "dependencies": {
         "fn.name": "1.x.x"
       }
+    },
+    "node_modules/parse-duration": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/parse-duration/-/parse-duration-1.1.0.tgz",
+      "integrity": "sha512-z6t9dvSJYaPoQq7quMzdEagSFtpGu+utzHqqxmpVWNNZRIXnvqyCvn9XsTdh7c/w0Bqmdz3RB3YnRaKtpRtEXQ=="
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dotenv": "^16.3.1",
     "lodash": "^4.17.21",
     "obscenity": "^0.1.4",
+    "parse-duration": "^1.1.0",
     "winston": "^3.11.0",
     "winston-daily-rotate-file": "^4.7.1"
   }

--- a/src/controllers/convenience/time.controller.ts
+++ b/src/controllers/convenience/time.controller.ts
@@ -30,13 +30,15 @@ const countdown = new Command(new SlashCommandBuilder()
     .setName("duration")
     .setDescription("Duration to count down from e.g. \"10s\".")
     .setRequired(true)
-  )
+  ),
+  { ephemeralOption: true },
 );
 
 countdown.execute(async (interaction) => {
   const context = formatContext(interaction);
 
   const options = interaction.options as CommandInteractionOptionResolver;
+  const ephemeral = !!options.getBoolean("ephemeral");
   const duration = options.getString("duration", true);
 
   const seconds = durationToSeconds(duration);
@@ -72,7 +74,7 @@ countdown.execute(async (interaction) => {
   const response =
     `Counting down to ${formatHoursMinsSeconds(seconds)} from now. ` +
     `Expiring ${toRelativeTimestampMention(endTimestamp)}...`
-  await interaction.reply(response);
+  await interaction.reply({ content: response, ephemeral });
 });
 
 const timeController = new Controller({

--- a/src/controllers/convenience/time.controller.ts
+++ b/src/controllers/convenience/time.controller.ts
@@ -1,0 +1,84 @@
+import {
+  CommandInteractionOptionResolver,
+  SlashCommandBuilder,
+} from "discord.js";
+import parseDuration from "parse-duration";
+
+import getLogger from "../../logger";
+import { Command, Controller } from "../../types/controller.types";
+import {
+  addDateSeconds,
+  formatHoursMinsSeconds,
+} from "../../utils/dates.utils";
+import { formatContext } from "../../utils/logging.utils";
+import {
+  toRelativeTimestampMention,
+  toUserMention,
+} from "../../utils/markdown.utils";
+
+const log = getLogger(__filename);
+
+function durationToSeconds(humanReadableDuration: string): number | null {
+  const seconds = parseDuration(humanReadableDuration, "sec");
+  return seconds ?? null;
+}
+
+const countdown = new Command(new SlashCommandBuilder()
+  .setName("countdown")
+  .setDescription("Start a countdown.")
+  .addStringOption(input => input
+    .setName("duration")
+    .setDescription("Duration to count down from e.g. \"10s\".")
+    .setRequired(true)
+  )
+);
+
+countdown.execute(async (interaction) => {
+  const context = formatContext(interaction);
+
+  const options = interaction.options as CommandInteractionOptionResolver;
+  const duration = options.getString("duration", true);
+
+  const seconds = durationToSeconds(duration);
+  if (seconds === null) {
+    log.info(`${context}: failed to parse \`${duration}\` as a duration.`);
+    await interaction.reply({
+      content: `Failed to interpret \`${duration}\` as a duration...`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  // I'm not dealing with edge cases from very small intervals.
+  if (seconds < 3) {
+    log.debug(`${context}: rejected seconds=${seconds}.`);
+    await interaction.reply({
+      content: "Duration must be at least 3 seconds!",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const endTimestamp = addDateSeconds(new Date(), seconds);
+  setTimeout(async () => {
+    const mention = toUserMention(interaction.member!.user.id);
+    log.debug(`${context}: countdown from ${seconds} ago expired.`);
+    await interaction.channel!.send(`${mention}, your countdown has expired!`);
+  }, seconds * 1000);
+  log.info(
+    `${context}: set timeout for ${seconds} seconds (ends at ${endTimestamp}).`
+  );
+
+  const response =
+    `Counting down to ${formatHoursMinsSeconds(seconds)} from now. ` +
+    `Expiring ${toRelativeTimestampMention(endTimestamp)}...`
+  await interaction.reply(response);
+});
+
+const timeController = new Controller({
+  name: "time",
+  commands: [countdown],
+  listeners: [],
+});
+
+export default timeController;


### PR DESCRIPTION
Title. A notable change that comes along with this PR is the addition of the `ephemeralOption` to `CommandOptions`, which is a the mutually exclusive counterpart to `broadcastOption`.