### PR TITLE
Fix not registering cooldown for dab listener

### DIFF
--- a/src/controllers/users/klee/dab.listener.ts
+++ b/src/controllers/users/klee/dab.listener.ts
@@ -1,6 +1,8 @@
-
 import getLogger from "../../../logger";
-import { CooldownManager } from "../../../middleware/cooldown.middleware";
+import {
+  CooldownManager,
+  useCooldown,
+} from "../../../middleware/cooldown.middleware";
 import {
   channelPollutionAllowed,
   contentMatching,
@@ -8,7 +10,10 @@ import {
 } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
-import { reactCustomEmoji, replySilently } from "../../../utils/interaction.utils";
+import {
+  reactCustomEmoji,
+  replySilently,
+} from "../../../utils/interaction.utils";
 import { formatContext } from "../../../utils/logging.utils";
 import uids from "../../../utils/uids.utils";
 
@@ -44,6 +49,9 @@ if (uids.KLEE === undefined) {
 } else {
   cooldown.setBypass(true, uids.KLEE);
 }
+
+onDab.filter(useCooldown(cooldown));
+onDab.saveCooldown(cooldown);
 
 const onDabSpec = onDab.toSpec();
 export default onDabSpec;


### PR DESCRIPTION
Emergency fix. Dab was triggering without cooldown due to me forgetting to `useCooldown(cooldown)` and `saveCooldown(cooldown)`.