### PR TITLE
Use ID for custom emojis, not name

### DIFF
--- a/src/controllers/moderation/profanity.listener.ts
+++ b/src/controllers/moderation/profanity.listener.ts
@@ -11,7 +11,6 @@ import {
   MessageListenerBuilder,
 } from "../../types/listener.types";
 import { GUILD_EMOJIS } from "../../utils/emojis.utils";
-import { reactCustomEmoji } from "../../utils/interaction.utils";
 import { formatContext } from "../../utils/logging.utils";
 
 const log = getLogger(__filename);
@@ -21,13 +20,10 @@ const profanityMatcher = new RegExpMatcher({
   ...englishRecommendedTransformers,
 });
 
-async function reactWithNekoGun(message: Message): Promise<boolean> {
-  const success = await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_GUN);
-  if (success) {
-    const context = formatContext(message);
-    log.debug(`${context}: detected profanity, reacted with gun emoji.`);
-  }
-  return success;
+async function reactWithNekoGun(message: Message): Promise<void> {
+  await message.react(GUILD_EMOJIS.NEKO_GUN);
+  const context = formatContext(message);
+  log.debug(`${context}: detected profanity, reacted with gun emoji.`);
 }
 
 function checkAndLogProfanityMatches(message: Message): boolean {

--- a/src/controllers/users/cxtie/rizz-emoji.listener.ts
+++ b/src/controllers/users/cxtie/rizz-emoji.listener.ts
@@ -2,14 +2,13 @@ import { messageFrom } from "../../../middleware/filters.middleware";
 import cxtieService from "../../../services/cxtie.service";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
-import { reactCustomEmoji } from "../../../utils/interaction.utils";
 
 const onRizzEmoji = new MessageListenerBuilder().setId("rizz-emoji");
 
 onRizzEmoji.filter(messageFrom("CXTIE"));
 onRizzEmoji.filter(cxtieService.containsCringeEmojis);
 onRizzEmoji.execute(async (message) => {
-  return await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_GUN);
+  await message.react(GUILD_EMOJIS.NEKO_GUN);
 });
 
 export default onRizzEmoji.toSpec();

--- a/src/controllers/users/cxtie/timer-reacter.listener.ts
+++ b/src/controllers/users/cxtie/timer-reacter.listener.ts
@@ -3,7 +3,6 @@ import { messageFrom } from "../../../middleware/filters.middleware";
 import cxtieService from "../../../services/cxtie.service";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
-import { reactCustomEmoji } from "../../../utils/interaction.utils";
 import { formatContext } from "../../../utils/logging.utils";
 
 const log = getLogger(__filename);
@@ -13,7 +12,7 @@ const randomReacter = new MessageListenerBuilder().setId("anti-cxtie");
 randomReacter.filter(messageFrom("CXTIE"));
 randomReacter.filter(_ => Math.random() < cxtieService.reactChance);
 randomReacter.execute(async (message) => {
-  await reactCustomEmoji(message, GUILD_EMOJIS.HMM);
+  await message.react(GUILD_EMOJIS.HMM);
   await message.react("⏲️");
   await message.react("❓");
   log.debug(`${formatContext(message)}: reacted with anti-Cxtie emojis.`);

--- a/src/controllers/users/klee/dab.listener.ts
+++ b/src/controllers/users/klee/dab.listener.ts
@@ -10,10 +10,7 @@ import {
 } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
-import {
-  reactCustomEmoji,
-  replySilently,
-} from "../../../utils/interaction.utils";
+import { replySilently } from "../../../utils/interaction.utils";
 import { formatContext } from "../../../utils/logging.utils";
 import uids from "../../../utils/uids.utils";
 
@@ -28,7 +25,7 @@ onDab.filter({
   predicate: (message) =>
     message.author.id === uids.KLEE || channelPollutionAllowed(message),
   onFail: async (message) =>
-    await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_L)
+    await message.react(GUILD_EMOJIS.NEKO_L),
 });
 
 onDab.execute(async (message) => {
@@ -40,7 +37,7 @@ const cooldown = new CooldownManager({
   type: "global",
   seconds: 600,
   async onCooldown(message) {
-    await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_L);
+    await message.react(GUILD_EMOJIS.NEKO_L);
   },
 });
 

--- a/src/controllers/users/wav/pookie.listener.ts
+++ b/src/controllers/users/wav/pookie.listener.ts
@@ -6,7 +6,6 @@ import {
 import { contentMatching } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
-import { reactCustomEmoji } from "../../../utils/interaction.utils";
 import uids from "../../../utils/uids.utils";
 
 const log = getLogger(__filename);
@@ -15,7 +14,7 @@ const onPookie = new MessageListenerBuilder().setId("pookie");
 
 onPookie.filter(contentMatching(/^pookie$/i));
 onPookie.execute(async (message) => {
-  return await reactCustomEmoji(message, GUILD_EMOJIS.NEKO_UWU);
+  await message.react(GUILD_EMOJIS.NEKO_UWU);
 });
 
 const cooldown = new CooldownManager({ type: "user", defaultSeconds: 300 });

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -14,10 +14,10 @@ export function parseCustomEmojis(content: string): CustomEmoji[] {
   return emojis;
 }
 
-/** Partial database of yung kai world's custom emoji names. */
+/** Partial database of yung kai world's custom emoji IDs. */
 export const GUILD_EMOJIS = {
-  NEKO_GUN: "kzNekogun",
-  HMM: "hmm",
-  NEKO_L: "nekocatL",
-  NEKO_UWU: "7482uwucat1",
+  NEKO_GUN: "1164956284760633364",
+  HMM: "1163463196275900547",
+  NEKO_L: "1164956350351167540",
+  NEKO_UWU: "1164956184277680129",
 };

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -1,4 +1,4 @@
-import { Events, GuildEmoji, Message, MessageFlags } from "discord.js";
+import { Events, Message, MessageFlags } from "discord.js";
 
 import getLogger from "../logger";
 import { ListenerExecuteFunction } from "../types/listener.types";
@@ -28,44 +28,4 @@ export function replySilentlyWith(content: string)
     await replySilently(message, content);
     log.debug(`${formatContext(message)}: replied with '${content}'.`);
   };
-}
-
-/**
- * Singleton class for managing custom emoji reactions. Custom emojis are
- * retrieved by and memoized by name.
- */
-class CustomEmojiReacter {
-  private namesToEmojiCache: Record<string, GuildEmoji> = {};
-
-  public react = async (
-    message: Message,
-    emojiName: string,
-  ): Promise<boolean> => {
-    let emoji: GuildEmoji;
-    if (emojiName in this.namesToEmojiCache) {
-      emoji = this.namesToEmojiCache[emojiName];
-    } else {
-      const emojiCache = message.guild?.emojis.cache;
-      const maybeEmoji = emojiCache?.find(emoji => emoji.name === emojiName);
-      if (!maybeEmoji) {
-        const context = formatContext(message);
-        log.warning(`${context}: no emoji with name '${emojiName}' found.`);
-        return false;
-      }
-      emoji = maybeEmoji;
-      this.namesToEmojiCache[emojiName] = emoji;
-    }
-
-    await message.react(emoji);
-    return true;
-  }
-}
-
-const customEmojiReacter = new CustomEmojiReacter();
-
-export async function reactCustomEmoji(
-  message: Message,
-  emojiName: string,
-): Promise<boolean> {
-  return await customEmojiReacter.react(message, emojiName);
 }


### PR DESCRIPTION
You can pass the ID directly to `Message#react`, meaning the whole `EmojiReacter` thing was redundant, and using `reactCustomEmoji()` was messing up mocking in testing anyway.