### PR TITLE
Fix bug of duplicate interaction replies

### DIFF
--- a/src/bot/command.runner.ts
+++ b/src/bot/command.runner.ts
@@ -41,6 +41,17 @@ export class CommandRunner {
     if (!passedChecks) return;
     const success = await this.runExecute(interaction);
     if (success) await this.runCleanups(interaction);
+
+    // Ensure that the user never sees "Application did not respond" if we can
+    // help it.
+    if (!interaction.replied) {
+      log.warning(
+        `${context}: execute didn't reply to interaction, ` +
+        "using generic response."
+      );
+      await interaction.reply({ content: "👍", ephemeral: true });
+    }
+
     log.debug(`${context}: finished executing command.`);
   }
 
@@ -111,13 +122,6 @@ export class CommandRunner {
       return false;
     }
 
-    if (!interaction.replied) {
-      log.warning(
-        `${context}: execute didn't reply to interaction, ` +
-        "using generic response."
-      );
-      await interaction.reply({ content: "👍", ephemeral: true });
-    }
     return success;
   }
 


### PR DESCRIPTION
Previously, I tried to be clever by having `CommandRunner#runExecute` check if the interaction was left not replied to and if so, reply with a generic response. However, this failed to account for possible cleanup callbacks that try to reply to the interaction, so when they try to reply, it causes a Discord API error. This should be fixed by moving the "fallback reply" code to the end of the top-level `CommandRunner#run` method.