### PR TITLE
Add npm script for running build files right away

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "clean": "rm -rf dist/*",
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "start": "npm run build && node .",
+    "now": "LOGGER_LEVEL=debug node .",
     "test": "jest"
   },
   "keywords": [],


### PR DESCRIPTION
I found myself using this shell command very often anyway, more so than `npm run dev` (which is more reliable but has a slower start-up time):

```sh
LOGGER_LEVEL=debug node .
```
