### PR TITLE
Extract controller loading and validate imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,9 @@
         "obscenity": "^0.1.4",
         "parse-duration": "^1.1.0",
         "winston": "^3.11.0",
-        "winston-daily-rotate-file": "^4.7.1"
+        "winston-daily-rotate-file": "^4.7.1",
+        "zod": "^3.22.4",
+        "zod-validation-error": "^2.1.0"
       },
       "devDependencies": {
         "@types/dotenv": "^8.2.0",
@@ -4585,6 +4587,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-2.1.0.tgz",
+      "integrity": "sha512-VJh93e2wb4c3tWtGgTa0OF/dTt/zoPCPzXq4V11ZjxmEAFaPi/Zss1xIZdEB5RD8GD00U0/iVXgqkF77RV7pdQ==",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.18.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
     "obscenity": "^0.1.4",
     "parse-duration": "^1.1.0",
     "winston": "^3.11.0",
-    "winston-daily-rotate-file": "^4.7.1"
+    "winston-daily-rotate-file": "^4.7.1",
+    "zod": "^3.22.4",
+    "zod-validation-error": "^2.1.0"
   }
 }

--- a/src/bot/command.loader.ts
+++ b/src/bot/command.loader.ts
@@ -1,0 +1,73 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ValidationError, fromZodError } from "zod-validation-error";
+
+import getLogger from "../logger";
+import { CommandSpec, commandSpecSchema } from "../types/command.types";
+
+const log = getLogger(__filename);
+
+export class CommandLoader {
+  constructor(
+    /**
+     * Path to the root directory containing custom command modules.
+     */
+    private commandsBaseDirectoryPath: string,
+  ) { }
+
+  private discoverCommandFiles(
+    directory: string = this.commandsBaseDirectoryPath,
+  ): string[] {
+    const commandPaths: string[] = [];
+
+    const contents = fs.readdirSync(directory);
+    for (const file of contents) {
+      const fullPath = path.join(directory, file);
+
+      // Recursive case: file is a directory.
+      if (fs.lstatSync(fullPath).isDirectory()) {
+        const innerCommandPaths = this.discoverCommandFiles(fullPath);
+        commandPaths.push(...innerCommandPaths);
+        continue;
+      }
+
+      // Base case: file is a controller file.
+      if (file.endsWith(".command.js") || file.endsWith("command.ts")) {
+        commandPaths.push(fullPath);
+        log.debug(
+          "discovered command implementation file: " +
+          `${path.relative(this.commandsBaseDirectoryPath, fullPath)}.`
+        );
+        continue;
+      }
+    }
+
+    return commandPaths;
+  }
+
+  private validateImport(spec: unknown): ValidationError | null {
+    const result = commandSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return fromZodError(result.error);
+    }
+    return null;
+  }
+
+  public load(): CommandSpec[] {
+    const specs: CommandSpec[] = [];
+    const commandPaths = this.discoverCommandFiles();
+
+    for (const fullPath of commandPaths) {
+      const commandSpec = require(fullPath).default as unknown;
+      const validationError = this.validateImport(commandSpec);
+      if (validationError) {
+        log.crit(`failed to import command module ${fullPath}.`);
+        throw validationError;
+      }
+      specs.push(commandSpec as CommandSpec);
+    }
+
+    return specs;
+  }
+}

--- a/src/bot/listener.loader.ts
+++ b/src/bot/listener.loader.ts
@@ -1,0 +1,92 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { ValidationError, fromZodError } from "zod-validation-error";
+
+import getLogger from "../logger";
+import { ListenerSpec, listenerSpecSchema } from "../types/listener.types";
+
+const log = getLogger(__filename);
+
+export class ListenerLoader {
+  constructor(
+    /**
+     * Path to root directory containing custom event listener modules.
+     */
+    private listenersBaseDirectoryPath: string,
+    /**
+     * Path to the directory containing event listener modules special to the
+     * bot itself.
+     */
+    private specialListenersDirectoryPath: string,
+  ) { }
+
+  private discoverSpecialListenerFiles(): string[] {
+    const specialListenerPaths: string[] = [];
+    const contents = fs.readdirSync(this.specialListenersDirectoryPath);
+    for (const file of contents) {
+      const fullPath = path.join(this.specialListenersDirectoryPath, file);
+      specialListenerPaths.push(fullPath);
+      log.debug(`discovered special event listener file: ${file}.`);
+    }
+    return specialListenerPaths;
+  }
+
+  private discoverListenerFiles(
+    directory: string = this.listenersBaseDirectoryPath,
+  ): string[] {
+    const listenerPaths: string[] = [];
+
+    // Prepend the listeners special to the bot itself.
+    listenerPaths.push(...this.discoverSpecialListenerFiles());
+
+    const contents = fs.readdirSync(directory);
+    for (const file of contents) {
+      const fullPath = path.join(directory, file);
+
+      // Recursive case: file is a directory.
+      if (fs.lstatSync(fullPath).isDirectory()) {
+        const innerCommandPaths = this.discoverListenerFiles(fullPath);
+        listenerPaths.push(...innerCommandPaths);
+        continue;
+      }
+
+      // Base case: file is a controller file.
+      if (file.endsWith(".listener.js") || file.endsWith("listener.ts")) {
+        listenerPaths.push(fullPath);
+        log.debug(
+          "discovered command implementation file: " +
+          `${path.relative(this.listenersBaseDirectoryPath, fullPath)}.`
+        );
+        continue;
+      }
+    }
+
+    return listenerPaths;
+  }
+
+  private validateImport(spec: unknown): ValidationError | null {
+    const result = listenerSpecSchema.safeParse(spec);
+    if (!result.success) {
+      return fromZodError(result.error);
+    }
+    return null;
+  }
+
+  public load(): ListenerSpec<any>[] {
+    const specs: ListenerSpec<any>[] = [];
+    const listenerPaths = this.discoverListenerFiles();
+
+    for (const fullPath of listenerPaths) {
+      const listenerSpec = require(fullPath).default as unknown;
+      const validationError = this.validateImport(listenerSpec);
+      if (validationError) {
+        log.crit(`failed to import listener module ${fullPath}.`);
+        throw validationError;
+      }
+      specs.push(listenerSpec as ListenerSpec<any>);
+    }
+
+    return specs;
+  }
+}

--- a/src/types/command.types.ts
+++ b/src/types/command.types.ts
@@ -5,6 +5,7 @@ import {
   RESTPostAPIChatInputApplicationCommandsJSONBody,
   SlashCommandBuilder,
 } from "discord.js";
+import { z } from "zod";
 
 export type CommandCheckFunction
   = (interaction: ChatInputCommandInteraction) => Awaitable<boolean>;
@@ -75,6 +76,26 @@ export type CommandSpec = {
    */
   autocomplete?: CommandAutocompleteHandler,
 };
+
+/**
+ * Schema for the `CommandSpec` type for Zod runtime parsing/validation.
+ *
+ * NOTE: This schema merely checks for the existence of and basic types of the
+ * expected keys, not the internal structure of all the values such as function
+ * argument/return types or JSON schema/class types that come from within
+ * discord.js. This schema is mostly meant to sanity check that the coders
+ * default exported the the correct type from a controller file.
+ */
+export const commandSpecSchema = z.object({
+  definition: z.object({ /* discord.js' JSON schema */ }),
+  checks: z.array(z.object({
+    predicate: z.function(),
+    onFail: z.function().optional(),
+    afterExecute: z.function().optional(),
+  })).optional(),
+  execute: z.function(),
+  autocomplete: z.function().optional(),
+});
 
 /**
  * Adding certain types of options makes the builder incompatible with

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -1,5 +1,6 @@
 import { Awaitable, ClientEvents, Events } from "discord.js";
 
+import { z } from "zod";
 import { CooldownManager } from "../middleware/cooldown.middleware";
 
 export type ListenerFilterFunction<Type extends keyof ClientEvents>
@@ -77,6 +78,28 @@ export type ListenerSpec<Type extends keyof ClientEvents> = {
    */
   cooldown?: Type extends Events.MessageCreate ? CooldownManager : never;
 };
+
+/**
+ * Schema for the `ListenerSpec` type for Zod runtime parsing/validation.
+ *
+ * NOTE: This schema merely checks for the existence of and basic types of the
+ * expected keys, not the internal structure of all the values such as function
+ * argument/return types or JSON schema/class types that come from within
+ * discord.js. This schema is mostly meant to sanity check that the coders
+ * default exported the the correct type from a controller file.
+ */
+export const listenerSpecSchema = z.object({
+  type: z.string(),
+  id: z.string(),
+  once: z.boolean().optional(),
+  filters: z.array(z.object({
+    predicate: z.function(),
+    onFail: z.function().optional(),
+    afterExecute: z.function().optional(),
+  })).optional(),
+  execute: z.function(),
+  cooldown: z.instanceof(CooldownManager).optional(),
+});
 
 /**
  * Utility class for constructing a `ListenerSpec` in a more readable way.


### PR DESCRIPTION
This PR principally does two things:

1. Uses [Zod](https://github.com/colinhacks/zod) to sanity check at runtime that the default export of discovered controller files are the correct type (`CommandSpec`, `ListenerSpec`). This is a DX feature since to my knowledge, there is no straightforward way to enforce (within TypeScript or the editor) that the `export default` of a certain file be a certain type. Thus, up until now, `BotClient` had just been trusting the developer, blindly using type assertions on `require(fullPath).default`. Now, we have a basic runtime validation check.
2. Extracts the logic for loading controller files into separate classes, `CommandLoader` and `ListenerLoader`, which are then instantiated within `BotClient` as an example of the *composition* design pattern.