### PR TITLE
Add response to "no <name> no"

### DIFF
--- a/src/controllers/users/cxtie/no-x-no.listener.ts
+++ b/src/controllers/users/cxtie/no-x-no.listener.ts
@@ -1,0 +1,27 @@
+import { CooldownManager, useCooldown } from "../../../middleware/cooldown.middleware";
+import {
+  channelPollutionAllowed,
+  contentMatching,
+} from "../../../middleware/filters.middleware";
+import { MessageListenerBuilder } from "../../../types/listener.types";
+import { replySilently } from "../../../utils/interaction.utils";
+
+const noXNo = new MessageListenerBuilder().setId("no-x-no");
+
+noXNo.filter(channelPollutionAllowed);
+noXNo.filter(contentMatching(/^no (.+) no$/i));
+noXNo.execute(async (message) => {
+  const { displayName } = message.author;
+  await replySilently(message, `no ${displayName} no`);
+});
+
+const cooldown = new CooldownManager({
+  type: "user",
+  defaultSeconds: 60,
+});
+
+noXNo.filter(useCooldown(cooldown));
+noXNo.saveCooldown(cooldown);
+
+const noXNoSpec = noXNo.toSpec();
+export default noXNoSpec;

--- a/tests/controllers/users/cxtie/no-x-no.listener.test.ts
+++ b/tests/controllers/users/cxtie/no-x-no.listener.test.ts
@@ -1,0 +1,12 @@
+import noXNoSpec from "../../../../src/controllers/users/cxtie/no-x-no.listener";
+import { MockMessage } from "../../../test-utils";
+
+describe("no-x-no listener", () => {
+  it("should respond with 'no <display name> no'", async () => {
+    const mock = new MockMessage(noXNoSpec)
+      .mockAuthor({ displayName: "tempbotfan" })
+      .mockContent("no bro no");
+    await mock.simulateEvent();
+    mock.expectRepliedSilentlyWith({ content: "no tempbotfan no" });
+  });
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -127,7 +127,8 @@ export function addMockGetter<PropertyType>(
 ): void;
 /**
  * Add a mock getter on the object. This is a workaround for jest-mock-extended
- * not supporting mocking getters yet.
+ * not supporting mocking getters yet. This can also be used to overwrite
+ * read-only properties.
  */
 export function addMockGetter<ValueType>(
   obj: Record<string, any>,
@@ -152,6 +153,14 @@ class TestClient extends IClientWithIntentsAndRunners {
   public override readonly listenerRunners
     = new Collection<string, ListenerRunner<any>>();
 }
+
+/**
+ * Parameter options for `MockMessage#mockAuthor`. To be extended over time.
+ */
+type AuthorOptions = Partial<{
+  uid: string,
+  displayName: string,
+}>;
 
 /**
  * Manager for mocking a message emitted by `Events.MessageCreate`.
@@ -201,8 +210,19 @@ export class MockMessage {
     return this;
   }
 
+  /**
+   * @deprecated Use the more general `mockAuthor` method instead.
+   */
   public mockAuthorId(uid: string): this {
     this.message.author.id = uid;
+    return this;
+  }
+
+  public mockAuthor(options: AuthorOptions): this {
+    if (options.uid !== undefined)
+      this.message.author.id = options.uid;
+    if (options.displayName !== undefined)
+      addMockGetter(this.message.author, "displayName", options.displayName);
     return this;
   }
 


### PR DESCRIPTION
Title. Several users, notably **Cxtie**, like to say "no <name> no" in response to something they don't approve of. Naturally, that lends to a new TempBot feature.

**Other changes:**
* Added basic sanity check test.
* Unit test entailed the addition of a new helper, `MockMessage#mockAuthor`, which is a generalized form of the now-deprecated `MockMessage#mockAuthorId` and is to be extended over time.