### PR TITLE
Appreciate Cxtie on sniffs half the time

### DIFF
--- a/src/controllers/users/cxtie/sniffs.listener.ts
+++ b/src/controllers/users/cxtie/sniffs.listener.ts
@@ -1,4 +1,3 @@
-
 import getLogger from "../../../logger";
 import {
   CooldownManager,
@@ -19,13 +18,21 @@ onSniffs.filter(message => {
   return !!message.content.match(sniffsWithPossibleMarkdown);
 });
 onSniffs.execute(async (message) => {
-  await replySilently(message, message.content);
   const context = formatContext(message);
-  log.info(`${context}: echoed sniffs.`);
+  const wouldSniffBack = Math.random() > 0.5;
+  if (wouldSniffBack) {
+    await replySilently(message, message.content);
+    log.info(`${context}: echoed sniffs.`);
+  } else {
+    await replySilently(message, "daily cxtie appreciation");
+    log.info(`${context}: appreciated cxtie.`);
+  }
 });
 
-const cooldown = new CooldownManager({ type: "global", seconds: 600 });
+const cooldown = new CooldownManager({ type: "global", seconds: 300 });
+
 onSniffs.filter(useCooldown(cooldown));
 onSniffs.saveCooldown(cooldown);
 
-export default onSniffs.toSpec();
+const onSniffsSpec = onSniffs.toSpec();
+export default onSniffsSpec;

--- a/tests/controllers/users/cxtie/sniffs.listener.test.ts
+++ b/tests/controllers/users/cxtie/sniffs.listener.test.ts
@@ -1,0 +1,28 @@
+const mockRandom = jest.fn();
+const mockMath = Object.create(global.Math);
+mockMath.random = mockRandom;
+global.Math = mockMath;
+
+import config from "../../../../src/config";
+import onSniffsSpec from "../../../../src/controllers/users/cxtie/sniffs.listener";
+import { MockMessage } from "../../../test-utils";
+
+describe("sniffs listener", () => {
+  it("should echo sniffs half the time", async () => {
+    const mock = new MockMessage(onSniffsSpec)
+      .mockContent("sniffs")
+      .mockAuthor({ uid: config.CXTIE_UID });
+    mockRandom.mockReturnValueOnce(0.99);
+    await mock.simulateEvent();
+    mock.expectRepliedSilentlyWith({ content: "sniffs" });
+  });
+
+  it("should appreciatie cxtie half the time", async () => {
+    const mock = new MockMessage(onSniffsSpec)
+      .mockContent("sniffs")
+      .mockAuthor({ uid: config.CXTIE_UID });
+    mockRandom.mockReturnValueOnce(0);
+    await mock.simulateEvent();
+    mock.expectRepliedSilentlyWith({ content: "daily cxtie appreciation" });
+  });
+});


### PR DESCRIPTION
**Feature requested by Cxtie.**

The `sniffs` message listener has been updated so that it randomly (50/50 chance) either:

* Echoes the sniffs back (existing functionality).
* Replies with `daily cxtie appreciation`.

Other changes:
* Lowered global cooldown: 600 -> 300 secs.
* Added sanity check unit tests.