### PR TITLE
Add channelPollutionAllowedOrBypass

### DIFF
--- a/src/controllers/users/klee/dab.listener.ts
+++ b/src/controllers/users/klee/dab.listener.ts
@@ -4,7 +4,7 @@ import {
   useCooldown,
 } from "../../../middleware/cooldown.middleware";
 import {
-  channelPollutionAllowed,
+  channelPollutionAllowedOrBypass,
   contentMatching,
   ignoreBots,
 } from "../../../middleware/filters.middleware";
@@ -21,11 +21,8 @@ const onDab = new MessageListenerBuilder().setId("dab");
 onDab.filter(ignoreBots);
 onDab.filter(contentMatching(/^dab$/i));
 onDab.filter({
-  // Klee's dab can bypass channel restrictions.
-  predicate: (message) =>
-    message.author.id === uids.KLEE || channelPollutionAllowed(message),
-  onFail: async (message) =>
-    await message.react(GUILD_EMOJIS.NEKO_L),
+  predicate: channelPollutionAllowedOrBypass(uids.KLEE),
+  onFail: async (message) => await message.react(GUILD_EMOJIS.NEKO_L),
 });
 
 onDab.execute(async (message) => {

--- a/src/controllers/users/ni/popipo.listener.ts
+++ b/src/controllers/users/ni/popipo.listener.ts
@@ -1,7 +1,10 @@
 import getLogger from "../../../logger";
-import { CooldownManager, useCooldown } from "../../../middleware/cooldown.middleware";
 import {
-  channelPollutionAllowed,
+  CooldownManager,
+  useCooldown,
+} from "../../../middleware/cooldown.middleware";
+import {
+  channelPollutionAllowedOrBypass,
   contentMatching,
 } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
@@ -14,10 +17,7 @@ const log = getLogger(__filename);
 const onPopipo = new MessageListenerBuilder().setId("popipo");
 
 onPopipo.filter(contentMatching(/popipo/i));
-onPopipo.filter(message => {
-  // Ni can bypass channel restrictions.
-  return message.author.id === uids.NI || channelPollutionAllowed(message);
-});
+onPopipo.filter(channelPollutionAllowedOrBypass(uids.NI));
 
 onPopipo.execute(async (message) => {
   const randomNum = randRange(2, 6);

--- a/src/middleware/filters.middleware.ts
+++ b/src/middleware/filters.middleware.ts
@@ -44,6 +44,7 @@ export function isPollutionImmuneChannel(
   return false;
 }
 
+
 /**
  * Only listen to messages created in a channel where pollution is "acceptable".
  * That is, the predicate should fail on "important" channels such as
@@ -57,6 +58,25 @@ export function contentMatching(
   pattern: string | RegExp,
 ): ListenerFilterFunction<Events.MessageCreate> {
   return message => !!message.content.match(pattern);
+}
+
+/**
+ * Same as `channelPollutionAllowed`, but taking in arguments and then returning
+ * the closure that can be passed into a builder filter. The arguments are user
+ * IDs of users that can bypass the channel pollution prevention policy.
+ */
+export function channelPollutionAllowedOrBypass(
+  // TODO: `| undefined` to accommodate undefined UIDs for now.
+  ...bypasserUids: (string | undefined)[]
+): ListenerFilterFunction<Events.MessageCreate> {
+  return function (message) {
+    const channel = message.channel as GuildTextBasedChannel
+    const pollutionAllowed = !isPollutionImmuneChannel(channel);
+    // TODO: filtering out undefined to accommodate undefined UIDs for now.
+    const canBypass = bypasserUids.filter(Boolean).includes(message.author.id);
+    console.log(pollutionAllowed, canBypass);
+    return pollutionAllowed || canBypass;
+  };
 }
 
 export function randomly(


### PR DESCRIPTION
Works similarly to the existing `channelPollutionAllowed`, except `channelPollutionAllowedOrBypass` *returns* a closure and instead itself takes in arguments: the user IDs of users that can bypass the channel pollution prevention policy.

This abbreviates the pattern of keeping the replies to an event listener out of important channels but also granting certain users special bypass of this policy.

Affected features:
* `dab` listener (**Klee**'s channel restriction bypass) (#9)
* `popipo` listener (**Ni**'s channel restriction bypass) (#35)