### PR TITLE
Fix logger clutter

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -95,7 +95,7 @@ export class BotClient extends IClientWithIntentsAndRunners {
   }
 
   private loadListeners(): void {
-    const allListenerSpecs = this.listenerLoader.load()
+    const allListenerSpecs = this.listenerLoader.load();
     for (const spec of allListenerSpecs) {
       const { id, type } = spec;
       this.listenerRunners.set(id, new ListenerRunner(spec));

--- a/src/bot/listener.loader.ts
+++ b/src/bot/listener.loader.ts
@@ -37,9 +37,6 @@ export class ListenerLoader {
   ): string[] {
     const listenerPaths: string[] = [];
 
-    // Prepend the listeners special to the bot itself.
-    listenerPaths.push(...this.discoverSpecialListenerFiles());
-
     const contents = fs.readdirSync(directory);
     for (const file of contents) {
       const fullPath = path.join(directory, file);
@@ -55,7 +52,7 @@ export class ListenerLoader {
       if (file.endsWith(".listener.js") || file.endsWith("listener.ts")) {
         listenerPaths.push(fullPath);
         log.debug(
-          "discovered command implementation file: " +
+          "discovered event listener implementation file: " +
           `${path.relative(this.listenersBaseDirectoryPath, fullPath)}.`
         );
         continue;
@@ -75,7 +72,9 @@ export class ListenerLoader {
 
   public load(): ListenerSpec<any>[] {
     const specs: ListenerSpec<any>[] = [];
-    const listenerPaths = this.discoverListenerFiles();
+    const customListenerPaths = this.discoverListenerFiles();
+    const specialListenerPaths = this.discoverSpecialListenerFiles();
+    const listenerPaths = [...specialListenerPaths, ...customListenerPaths];
 
     for (const fullPath of listenerPaths) {
       const listenerSpec = require(fullPath).default as unknown;

--- a/src/middleware/filters.middleware.ts
+++ b/src/middleware/filters.middleware.ts
@@ -74,7 +74,6 @@ export function channelPollutionAllowedOrBypass(
     const pollutionAllowed = !isPollutionImmuneChannel(channel);
     // TODO: filtering out undefined to accommodate undefined UIDs for now.
     const canBypass = bypasserUids.filter(Boolean).includes(message.author.id);
-    console.log(pollutionAllowed, canBypass);
     return pollutionAllowed || canBypass;
   };
 }


### PR DESCRIPTION
The logs were being cluttered with some unexpected debug statements:

* A stray `console.log()` from when I was testing the new `channelPollutionAllowedOrBypass` filter (#36).
* `ListenerLoader` repeatedly "discovering" the special event listener modules (`src/bot/listeners`). The problem was that special listener discovery was being called from within `discoverListenerFiles()`, which is itself **recursive**, so the `listenerPaths` array was being extended with duplicate paths every call frame.
* Also fixed a typo where `ListenerLoader` logged "discovered *command* implementation file".