### PR TITLE
Make bot remember how long it's been running

### DIFF
--- a/src/bot/listeners/ready.listener.ts
+++ b/src/bot/listeners/ready.listener.ts
@@ -1,11 +1,14 @@
 import { Client, Events } from "discord.js";
 
 import getLogger from "../../logger";
+import { IClientWithIntentsAndRunners } from "../../types/client.abc";
 import { ListenerBuilder, ListenerSpec } from "../../types/listener.types";
 
 const log = getLogger(__filename);
 
 async function handleReady(client: Client): Promise<void> {
+  const now = new Date();
+  (client as IClientWithIntentsAndRunners).readySince = now;
   log.info(`bot ready! Logged in as ${client.user?.tag}.`);
 }
 

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -19,6 +19,8 @@ export abstract class IClientWithIntentsAndRunners extends Client {
   public abstract readonly listenerRunners
     : Collection<string, ListenerRunner<any>>;
 
+  public readySince?: Date;
+
   constructor() {
     super({
       intents: [

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -1,7 +1,9 @@
 import pingSpec from "../../../src/controllers/dev/ping.command";
+import { toRelativeTimestampMention, toTimestampMention } from "../../../src/utils/markdown.utils";
 
 import {
   MockInteraction,
+  TestClient,
   addMockGetter
 } from "../../test-utils";
 
@@ -11,16 +13,23 @@ describe("/ping command", () => {
     mock = new MockInteraction(pingSpec);
   });
 
-  it("should respond with a message, latency, and branch details", async () => {
+  it("should respond with latency, branch, startup details", async () => {
     const dummyPing = 42;
-    addMockGetter(mock.interaction.client.ws, "ping", dummyPing);
+    const dummyReadySince = new Date();
+
+    const mockClient = new TestClient();
+    mockClient.readySince = dummyReadySince;
+    addMockGetter(mockClient.ws, "ping", dummyPing);
+    mock.mockClient(mockClient);
 
     await mock.simulateCommand();
 
+    const timestamp = toTimestampMention(dummyReadySince);
+    const relativeTimestamp = toRelativeTimestampMention(dummyReadySince);
     const expectedParts = [
-      "Hello there!",
       `Latency: **${dummyPing}**`,
       "Branch: ",
+      `Ready: ${timestamp} (${relativeTimestamp})`,
     ];
     for (const part of expectedParts) {
       mock.expectRepliedWith({

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -63,13 +63,24 @@ export class MockInteraction {
   /**
    * ARRANGE.
    *
+   * Mock the client attached to the interaction.
+   */
+  public mockClient(client: IClientWithIntentsAndRunners): this {
+    addMockGetter(this.interaction, "client", client);
+    return this;
+  }
+
+  /**
+   * ARRANGE.
+   *
    * Mock that the caller of this interaction has the roles specified by the
    * provided IDs.
    */
-  public mockCallerRoles(...roleIds: string[]): void {
+  public mockCallerRoles(...roleIds: string[]): this {
     const member = this.interaction.member as DeepMockProxy<GuildMember>;
     const matcher = new Matcher<string>(roleId => roleIds.includes(roleId), "");
     member.roles.cache.has.calledWith(matcher).mockReturnValue(true);
+    return this;
   }
 
   /**
@@ -77,10 +88,11 @@ export class MockInteraction {
    *
    * Mock an option value on this interaction.
    */
-  public mockOption(type: OptionType, name: string, value: any): void {
+  public mockOption(type: OptionType, name: string, value: any): this {
     const options
       = this.interaction.options as DeepMockProxy<CommandInteractionOptionResolver>;
     options[`get${type}`].calledWith(name).mockReturnValue(value);
+    return this;
   }
 
 
@@ -147,7 +159,7 @@ export function addMockGetter<ValueType>(
   return mockGetter;
 }
 
-class TestClient extends IClientWithIntentsAndRunners {
+export class TestClient extends IClientWithIntentsAndRunners {
   public override readonly commandRunners
     = new Collection<string, CommandRunner>();
   public override readonly listenerRunners


### PR DESCRIPTION
`/ping` now also reveals the timestamp (and relative timestamp) from which the bot was started (measured by when the ready event is emitted).

**Notes:**
* This involved exposing a `readySince` property on the bot class (`IClientWithIntentsAndRunners`, for the Dependency Inversion principle).
* The special `clientReady` event handler then sets this property.
* The `/ping` command serves as the front-end for this functionality, reporting the timestamp since which the bot has been running, in addition to previous details.
* Made some changes to `MockInteraction` while I was at it -- notably, making the *ARRANGE* methods return `this` to support the builder pattern, consistent with its event listener analog, `MockMessage`.