### PR TITLE
Enhance randomly filter to support callback arg

### DIFF
--- a/src/controllers/users/cxtie/timer-reacter.listener.ts
+++ b/src/controllers/users/cxtie/timer-reacter.listener.ts
@@ -1,5 +1,5 @@
 import getLogger from "../../../logger";
-import { messageFrom } from "../../../middleware/filters.middleware";
+import { messageFrom, randomly } from "../../../middleware/filters.middleware";
 import cxtieService from "../../../services/cxtie.service";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
@@ -10,7 +10,7 @@ const log = getLogger(__filename);
 const randomReacter = new MessageListenerBuilder().setId("anti-cxtie");
 
 randomReacter.filter(messageFrom("CXTIE"));
-randomReacter.filter(_ => Math.random() < cxtieService.reactChance);
+randomReacter.filter(randomly(() => cxtieService.reactChance));
 randomReacter.execute(async (message) => {
   await message.react(GUILD_EMOJIS.HMM);
   await message.react("⏲️");
@@ -18,4 +18,5 @@ randomReacter.execute(async (message) => {
   log.debug(`${formatContext(message)}: reacted with anti-Cxtie emojis.`);
 });
 
-export default randomReacter.toSpec();
+const randomReacterSpec = randomReacter.toSpec();
+export default randomReacterSpec;

--- a/src/controllers/users/luke/random-meow.listener.ts
+++ b/src/controllers/users/luke/random-meow.listener.ts
@@ -3,6 +3,7 @@ import getLogger from "../../../logger";
 import {
   channelPollutionAllowed,
   messageFrom,
+  randomly,
 } from "../../../middleware/filters.middleware";
 import lukeService from "../../../services/luke.service";
 import { MessageListenerBuilder } from "../../../types/listener.types";
@@ -15,7 +16,7 @@ const randomMeower = new MessageListenerBuilder().setId("meow");
 
 randomMeower.filter(channelPollutionAllowed);
 randomMeower.filter(messageFrom("LUKE"));
-randomMeower.filter(_ => Math.random() < lukeService.getMeowChance());
+randomMeower.filter(randomly(lukeService.getMeowChance));
 randomMeower.execute(async (message) => {
   await replySilently(message, "meow meow");
   log.debug(`${formatContext(message)}: meowed at Luke.`);

--- a/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
+++ b/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
@@ -1,0 +1,57 @@
+const mockRandom = jest.fn();
+const mockMath = Object.create(global.Math);
+mockMath.random = mockRandom;
+global.Math = mockMath;
+
+jest.mock("../../../../src/services/cxtie.service");
+
+import config from "../../../../src/config";
+import randomReacterSpec from "../../../../src/controllers/users/cxtie/timer-reacter.listener";
+import cxtieService from "../../../../src/services/cxtie.service";
+import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
+import { MockMessage, addMockGetter } from "../../../test-utils";
+
+const mockedCxtieService = jest.mocked(cxtieService);
+const mockReactChanceGetter = jest.fn();
+addMockGetter(mockedCxtieService, "reactChance", () => mockReactChanceGetter());
+
+describe("anti-cxtie listener", () => {
+  let mock: MockMessage;
+  beforeEach(() => {
+    mock = new MockMessage(randomReacterSpec)
+      .mockAuthor({ uid: config.CXTIE_UID });
+  })
+
+  describe("should meow randomly based on chance computed by service", () => {
+    it("should meow", async () => {
+      mockReactChanceGetter.mockReturnValueOnce(0.05);
+      mockRandom.mockReturnValueOnce(0.01);
+
+      await mock.simulateEvent();
+
+      mock.expectReactedWith(GUILD_EMOJIS.HMM, "⏲️", "❓");
+    });
+
+    it("shouldn't meow", async () => {
+      mockReactChanceGetter.mockReturnValueOnce(0.05);
+      mockRandom.mockReturnValueOnce(0.42);
+
+      await mock.simulateEvent();
+
+      mock.expectNotResponded();
+    });
+
+    it("shouldn't meow and then meow (dynamic meow chance)", async () => {
+      mockReactChanceGetter
+        .mockReturnValueOnce(0.05)
+        .mockReturnValueOnce(0.95);
+      mockRandom.mockReturnValue(0.50);
+
+      await mock.simulateEvent();
+      mock.expectNotResponded();
+
+      await mock.simulateEvent();
+      mock.expectReactedWith(GUILD_EMOJIS.HMM, "⏲️", "❓");
+    });
+  });
+});

--- a/tests/controllers/users/luke/random-meow.listener.test.ts
+++ b/tests/controllers/users/luke/random-meow.listener.test.ts
@@ -1,0 +1,54 @@
+const mockRandom = jest.fn();
+const mockMath = Object.create(global.Math);
+mockMath.random = mockRandom;
+global.Math = mockMath;
+
+jest.mock("../../../../src/services/luke.service");
+
+import config from "../../../../src/config";
+import randomMeowerSpec from "../../../../src/controllers/users/luke/random-meow.listener";
+import lukeService from "../../../../src/services/luke.service";
+import { MockMessage } from "../../../test-utils";
+
+const mockedLukeService = jest.mocked(lukeService);
+
+describe("random-meow listener", () => {
+  let mock: MockMessage;
+  beforeEach(() => {
+    mock = new MockMessage(randomMeowerSpec)
+      .mockAuthor({ uid: config.LUKE_UID });
+  })
+
+  describe("should meow randomly based on chance computed by service", () => {
+    it("should meow", async () => {
+      mockedLukeService.getMeowChance.mockReturnValueOnce(0.05);
+      mockRandom.mockReturnValueOnce(0.01);
+
+      await mock.simulateEvent();
+
+      mock.expectRepliedSilentlyWith({ content: "meow meow" });
+    });
+
+    it("shouldn't meow", async () => {
+      mockedLukeService.getMeowChance.mockReturnValueOnce(0.05);
+      mockRandom.mockReturnValueOnce(0.42);
+
+      await mock.simulateEvent();
+
+      mock.expectNotResponded();
+    });
+
+    it("shouldn't meow and then meow (dynamic meow chance)", async () => {
+      mockedLukeService.getMeowChance
+        .mockReturnValueOnce(0.05)
+        .mockReturnValueOnce(0.95);
+      mockRandom.mockReturnValue(0.50);
+
+      await mock.simulateEvent();
+      mock.expectNotResponded();
+
+      await mock.simulateEvent();
+      mock.expectRepliedSilentlyWith({ content: "meow meow" });
+    });
+  });
+});


### PR DESCRIPTION
This allows `randomly()` to support dynamic ("computed") probabilities in real time instead of using the same constant every time. The latter was why the features that could've benefited from this (listed below) used an inline callback with `Math.random() < someServiceFunction()` instead. This PR makes it so this functionality can be integrated into the filter itself returned by `randomly()`.

**Affected features**:
* `meow` event listener (**Luke**)
* `anti-cxtie` event listener (**Cxtie**, #11)

These features used the `LukeService` and `CxtieService` respectively to maintain their respective (mutable) probabilities, making the probability dynamic. They have been refactored to use the enhanced version of `randomly()`.