### PR TITLE
Write tests for services and most utils

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -28,9 +28,10 @@ const config: Config = {
   coverageDirectory: "coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
-  // coveragePathIgnorePatterns: [
-  //   "\\\\node_modules\\\\"
-  // ],
+  coveragePathIgnorePatterns: [
+    "\\\\node_modules\\\\",
+    "tests/",
+  ],
 
   // Indicates which provider should be used to instrument code for coverage
   // coverageProvider: "babel",

--- a/src/services/cxtie.service.ts
+++ b/src/services/cxtie.service.ts
@@ -12,7 +12,7 @@ export const SUP_EMOJI_ID = "1171056612761403413"
 export const SLAY_EMOJI_ID = "1176908139896000623";
 
 export class CxtieService {
-  public static INIT_TIMER_REACT_CHANCE = 0.05;
+  public static readonly INIT_TIMER_REACT_CHANCE = 0.05;
   private currentReactChance = CxtieService.INIT_TIMER_REACT_CHANCE;
 
   public get reactChance(): number { return this.currentReactChance; }

--- a/src/services/luke.service.ts
+++ b/src/services/luke.service.ts
@@ -7,7 +7,7 @@ import { formatContext } from "../utils/logging.utils";
 const log = getLogger(__filename);
 
 export class LukeService {
-  public static INIT_MEOW_CHANCE = 0.05;
+  public static readonly INIT_MEOW_CHANCE = 0.05;
   private meowChance = LukeService.INIT_MEOW_CHANCE;
 
   public getMeowChance = (): number => {

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -3,6 +3,9 @@ export type CustomEmoji = {
   id: string;
 };
 
+/**
+ * Extract custom emojis from a content string.
+ */
 export function parseCustomEmojis(content: string): CustomEmoji[] {
   const CUSTOM_EMOJI_REGEXP = /<:(.+?):(\d+?)>/g;
   const matches = content.matchAll(CUSTOM_EMOJI_REGEXP);
@@ -12,6 +15,15 @@ export function parseCustomEmojis(content: string): CustomEmoji[] {
     emojis.push({ name, id });
   }
   return emojis;
+}
+
+/**
+ * Return the custom emoji in "escaped" form (with name and ID, how they are
+ * encoded in a content string payload).
+ */
+export function toEscapedEmoji(emoji: CustomEmoji): string {
+  const { name, id } = emoji;
+  return `<:${name}:${id}>`;
 }
 
 /** Partial database of yung kai world's custom emoji IDs. */

--- a/src/utils/iteration.utils.ts
+++ b/src/utils/iteration.utils.ts
@@ -22,24 +22,6 @@ export function iterateEnum<T extends {}>(enumerable: T)
 }
 
 /**
- * Equivalent of Python's `zip()` for two arrays. Example usage:
- *
- *    ```
- *    const numbers = [1, 2, 3];
- *    const words = ['one', 'two', 'three'];
- *    const zipped = zip(numbers, words);
- *    console.log(zipped);
- *    // Output: [ [ 1, 'one' ], [ 2, 'two' ], [ 3, 'three' ] ]
- *    ```
- *
- * Attribution: ChatGPT.
- */
-export function zip<T, U>(array1: T[], array2: U[]): [T, U][] {
-  const length = Math.min(array1.length, array2.length);
-  return Array.from({ length }, (_, index) => [array1[index], array2[index]]);
-}
-
-/**
  * Resolve a mentionable into an array of member objects.
  */
 export function getAllMembers(mentionable: GuildMember | Role): GuildMember[] {

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -23,7 +23,7 @@ export function joinUserMentions(userIds?: Iterable<string>): string {
 /**
  * See: https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa.
  */
-export const enum TimestampFormat {
+export enum TimestampFormat {
   /** 12-hour Example: 9:01 AM */
   SHORT_TIME = "t",
   /** 12-hour Example: 9:01:00 AM */

--- a/tests/controllers/users/cxtie/rizz.listener.test.ts
+++ b/tests/controllers/users/cxtie/rizz.listener.test.ts
@@ -1,14 +1,19 @@
 import config from "../../../../src/config";
 import onRizzSpec from "../../../../src/controllers/users/cxtie/rizz.listener";
 import { SUP_EMOJI_ID } from "../../../../src/services/cxtie.service";
-import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
+import {
+  CustomEmoji,
+  GUILD_EMOJIS,
+  toEscapedEmoji,
+} from "../../../../src/utils/emojis.utils";
 import { MockMessage } from "../../../test-utils";
 
 describe("rizz listener", () => {
   it("should react if content contains cringe emojis", async () => {
+    const sup: CustomEmoji = { id: SUP_EMOJI_ID, name: "sup" };
     const mock = new MockMessage(onRizzSpec)
       .mockAuthorId(config.CXTIE_UID!)
-      .mockContent(`<:sup:${SUP_EMOJI_ID}>`);
+      .mockContent(toEscapedEmoji(sup));
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_GUN);
   });

--- a/tests/controllers/users/cxtie/sniffs.listener.test.ts
+++ b/tests/controllers/users/cxtie/sniffs.listener.test.ts
@@ -1,18 +1,17 @@
-const mockRandom = jest.fn();
-const mockMath = Object.create(global.Math);
-mockMath.random = mockRandom;
-global.Math = mockMath;
-
 import config from "../../../../src/config";
 import onSniffsSpec from "../../../../src/controllers/users/cxtie/sniffs.listener";
 import { MockMessage } from "../../../test-utils";
 
 describe("sniffs listener", () => {
+  afterEach(() => {
+    jest.spyOn(global.Math, "random").mockRestore();
+  })
+
   it("should echo sniffs half the time", async () => {
     const mock = new MockMessage(onSniffsSpec)
       .mockContent("sniffs")
       .mockAuthor({ uid: config.CXTIE_UID });
-    mockRandom.mockReturnValueOnce(0.99);
+    jest.spyOn(global.Math, "random").mockReturnValueOnce(0.99);
     await mock.simulateEvent();
     mock.expectRepliedSilentlyWith({ content: "sniffs" });
   });
@@ -21,7 +20,7 @@ describe("sniffs listener", () => {
     const mock = new MockMessage(onSniffsSpec)
       .mockContent("sniffs")
       .mockAuthor({ uid: config.CXTIE_UID });
-    mockRandom.mockReturnValueOnce(0);
+    jest.spyOn(global.Math, "random").mockReturnValueOnce(0);
     await mock.simulateEvent();
     mock.expectRepliedSilentlyWith({ content: "daily cxtie appreciation" });
   });

--- a/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
+++ b/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
@@ -1,8 +1,3 @@
-const mockRandom = jest.fn();
-const mockMath = Object.create(global.Math);
-mockMath.random = mockRandom;
-global.Math = mockMath;
-
 jest.mock("../../../../src/services/cxtie.service");
 
 import config from "../../../../src/config";
@@ -20,32 +15,36 @@ describe("anti-cxtie listener", () => {
   beforeEach(() => {
     mock = new MockMessage(randomReacterSpec)
       .mockAuthor({ uid: config.CXTIE_UID });
-  })
+  });
 
-  describe("should meow randomly based on chance computed by service", () => {
+  afterEach(() => {
+    jest.spyOn(global.Math, "random").mockRestore();
+  });
+
+  describe("should react randomly based on chance computed by service", () => {
     it("should meow", async () => {
       mockReactChanceGetter.mockReturnValueOnce(0.05);
-      mockRandom.mockReturnValueOnce(0.01);
+      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.01);
 
       await mock.simulateEvent();
 
       mock.expectReactedWith(GUILD_EMOJIS.HMM, "⏲️", "❓");
     });
 
-    it("shouldn't meow", async () => {
+    it("shouldn't react", async () => {
       mockReactChanceGetter.mockReturnValueOnce(0.05);
-      mockRandom.mockReturnValueOnce(0.42);
+      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.42);
 
       await mock.simulateEvent();
 
       mock.expectNotResponded();
     });
 
-    it("shouldn't meow and then meow (dynamic meow chance)", async () => {
+    it("shouldn't react and then react (dynamic meow chance)", async () => {
       mockReactChanceGetter
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
-      mockRandom.mockReturnValue(0.50);
+      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.50);
 
       await mock.simulateEvent();
       mock.expectNotResponded();

--- a/tests/controllers/users/luke/random-meow.listener.test.ts
+++ b/tests/controllers/users/luke/random-meow.listener.test.ts
@@ -1,8 +1,3 @@
-const mockRandom = jest.fn();
-const mockMath = Object.create(global.Math);
-mockMath.random = mockRandom;
-global.Math = mockMath;
-
 jest.mock("../../../../src/services/luke.service");
 
 import config from "../../../../src/config";
@@ -19,10 +14,14 @@ describe("random-meow listener", () => {
       .mockAuthor({ uid: config.LUKE_UID });
   })
 
+  afterEach(() => {
+    jest.spyOn(global.Math, "random").mockRestore();
+  });
+
   describe("should meow randomly based on chance computed by service", () => {
     it("should meow", async () => {
       mockedLukeService.getMeowChance.mockReturnValueOnce(0.05);
-      mockRandom.mockReturnValueOnce(0.01);
+      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.01);
 
       await mock.simulateEvent();
 
@@ -31,7 +30,7 @@ describe("random-meow listener", () => {
 
     it("shouldn't meow", async () => {
       mockedLukeService.getMeowChance.mockReturnValueOnce(0.05);
-      mockRandom.mockReturnValueOnce(0.42);
+      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.42);
 
       await mock.simulateEvent();
 
@@ -42,7 +41,7 @@ describe("random-meow listener", () => {
       mockedLukeService.getMeowChance
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
-      mockRandom.mockReturnValue(0.50);
+      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.50);
 
       await mock.simulateEvent();
       mock.expectNotResponded();

--- a/tests/services/cxtie.service.test.ts
+++ b/tests/services/cxtie.service.test.ts
@@ -1,0 +1,56 @@
+import { Message } from "discord.js";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+import { CxtieService, SLAY_EMOJI_ID, SUP_EMOJI_ID } from "../../src/services/cxtie.service";
+import { CustomEmoji, toEscapedEmoji } from "../../src/utils/emojis.utils";
+
+let cxtieService: CxtieService;
+beforeEach(() => {
+  cxtieService = new CxtieService();
+});
+
+describe("react chance", () => {
+  it("should start with the initial react chance", () => {
+    const chance = cxtieService.reactChance;
+    expect(chance).toBeCloseTo(CxtieService.INIT_TIMER_REACT_CHANCE);
+  });
+
+  it("should reflect the updated react chance", () => {
+    cxtieService.reactChance = 0.42;
+    const newChance = cxtieService.reactChance;
+    expect(newChance).toBeCloseTo(0.42);
+  });
+});
+
+describe("cringe emoji detection", () => {
+  function getMockMessage(content: string): DeepMockProxy<Message> {
+    const mockMessage = mockDeep<Message>();
+    mockMessage.content = content;
+    return mockMessage;
+  }
+
+  it("should detect the sup emoji", () => {
+    const sup: CustomEmoji = { id: SUP_EMOJI_ID, name: "sup" };
+    const mockMessage = getMockMessage(toEscapedEmoji(sup));
+
+    const result = cxtieService.containsCringeEmojis(mockMessage);
+
+    expect(result).toEqual(true);
+  });
+
+  it("should detect the slay emoji", () => {
+    const slay: CustomEmoji = { id: SLAY_EMOJI_ID, name: "slay" };
+    const mockMessage = getMockMessage(toEscapedEmoji(slay));
+
+    const result = cxtieService.containsCringeEmojis(mockMessage);
+
+    expect(result).toEqual(true);
+  });
+
+  it("should return false if neither emoji is present", () => {
+    const mockMessage = getMockMessage("an ordinary message");
+
+    const result = cxtieService.containsCringeEmojis(mockMessage);
+
+    expect(result).toEqual(false);
+  });
+});

--- a/tests/services/luke.service.test.ts
+++ b/tests/services/luke.service.test.ts
@@ -1,0 +1,101 @@
+import { Message } from "discord.js";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+
+import { LukeService } from "../../src/services/luke.service";
+import { addMockGetter } from "../test-utils";
+
+let lukeService: LukeService;
+beforeEach(() => {
+  lukeService = new LukeService();
+})
+
+describe("meow chance", () => {
+  it("should start with the initial meow chance", () => {
+    const chance = lukeService.getMeowChance();
+    expect(chance).toBeCloseTo(LukeService.INIT_MEOW_CHANCE);
+  });
+
+  it("should reflect the updated meow chance", () => {
+    lukeService.setMeowChance(0.42);
+    const newChance = lukeService.getMeowChance()
+    expect(newChance).toBeCloseTo(0.42);
+  });
+});
+
+describe("dad joke handler", () => {
+  // ARRANGE.
+  function getMockMessage(content: string): DeepMockProxy<Message> {
+    const mockMessage = mockDeep<Message>();
+    mockMessage.content = content;
+    addMockGetter(mockMessage.member!, "displayName", "test-user");
+    addMockGetter(mockMessage.client.user, "displayName", "test-bot-user");
+    return mockMessage;
+  }
+
+  // ASSERT.
+  function expectRepliedWith(
+    mockMessage: DeepMockProxy<Message>,
+    content: string,
+  ): void {
+    expect(mockMessage.reply).toHaveBeenCalledWith(
+      expect.objectContaining({ content })
+    );
+  }
+
+  it("should respond with the affirmative Dad joke", async () => {
+    const mockMessage = getMockMessage("i am really weird and things");
+
+    const result = await lukeService.processDadJoke(mockMessage);
+
+    expect(result).toEqual(true);
+    expectRepliedWith(
+      mockMessage,
+      "Hi really weird and things, I'm test-bot-user!",
+    );
+  });
+
+  it("should respond with the negative Dad joke", async () => {
+    const mockMessage = getMockMessage("i am not really weird");
+
+    const result = await lukeService.processDadJoke(mockMessage);
+
+    expect(result).toEqual(true);
+    expectRepliedWith(
+      mockMessage,
+      "Of course you're not really weird, you're test-user!",
+    );
+  });
+
+  it("should not respond if the trigger is not detected", async () => {
+    const mockMessage = getMockMessage("an ordinary message");
+
+    const result = await lukeService.processDadJoke(mockMessage);
+
+    expect(result).toEqual(false);
+    expect(mockMessage.reply).not.toHaveBeenCalled();
+  });
+
+  it("should trigger even with contractions (w/ punctuation)", async () => {
+    const mockMessage = getMockMessage("i'm really weird and things");
+
+    const result = await lukeService.processDadJoke(mockMessage);
+
+    expect(result).toEqual(true);
+    expectRepliedWith(
+      mockMessage,
+      "Hi really weird and things, I'm test-bot-user!",
+    );
+  });
+
+  it("should trigger even with contractions (w/o punctuation)", async () => {
+    const mockMessage = getMockMessage("im really weird and things");
+
+    const result = await lukeService.processDadJoke(mockMessage);
+
+    expect(result).toEqual(true);
+    expectRepliedWith(
+      mockMessage,
+      "Hi really weird and things, I'm test-bot-user!",
+    );
+  });
+});

--- a/tests/utils/emojis.utils.test.ts
+++ b/tests/utils/emojis.utils.test.ts
@@ -1,0 +1,34 @@
+import { CustomEmoji, parseCustomEmojis, toEscapedEmoji } from "../../src/utils/emojis.utils";
+
+describe("parsing custom emojis", () => {
+  it("should return all custom emojis in string", () => {
+    const dummy1 = "<:dummy1:123456789>";
+    const dummy2 = "<:dummy2:987654321>";
+    const content = `i'm a ${dummy1} but you're a ${dummy2}!`;
+
+    const result = parseCustomEmojis(content);
+
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual<CustomEmoji>({
+      name: "dummy1",
+      id: "123456789",
+    });
+    expect(result[1]).toEqual<CustomEmoji>({
+      name: "dummy2",
+      id: "987654321",
+    });
+  });
+});
+
+describe("encoding custom emojis", () => {
+  it("should return the emoji in proper escaped format", () => {
+    const dummy: CustomEmoji = {
+      name: "dummy",
+      id: "4242424242",
+    };
+
+    const result = toEscapedEmoji(dummy);
+
+    expect(result).toEqual(`<:${dummy.name}:${dummy.id}>`);
+  });
+});

--- a/tests/utils/interaction.utils.test.ts
+++ b/tests/utils/interaction.utils.test.ts
@@ -1,0 +1,43 @@
+jest.mock("../../src/utils/logging.utils");
+
+import { Message, MessageFlags, MessageReplyOptions } from "discord.js";
+import { replySilently, replySilentlyWith } from "../../src/utils/interaction.utils";
+
+const mockMessage = {
+  reply: jest.fn(),
+} as unknown as Message;
+
+describe("replying silently to a message", () => {
+  it("should disable all mentions", async () => {
+    await replySilently(mockMessage, "hello there");
+    expect(mockMessage.reply).toHaveBeenCalledWith(
+      expect.objectContaining<MessageReplyOptions>({
+        allowedMentions: expect.objectContaining({ parse: [] }),
+      }),
+    );
+  });
+
+  it("should suppress notifications", async () => {
+    await replySilently(mockMessage, "hello there");
+    expect(mockMessage.reply).toHaveBeenCalledWith(
+      expect.objectContaining<MessageReplyOptions>({
+        flags: MessageFlags.SuppressNotifications,
+      }),
+    );
+  });
+});
+
+describe("replying silently (as a callback)", () => {
+  it("should return a closure equivalent to replySilently", async () => {
+    const closure = replySilentlyWith("hello there");
+
+    await closure(mockMessage);
+
+    expect(mockMessage.reply).toHaveBeenCalledWith(
+      expect.objectContaining<MessageReplyOptions>({
+        allowedMentions: expect.objectContaining({ parse: [] }),
+        flags: MessageFlags.SuppressNotifications,
+      }),
+    );
+  });
+});

--- a/tests/utils/iteration.utils.test.ts
+++ b/tests/utils/iteration.utils.test.ts
@@ -1,0 +1,29 @@
+import { Collection, Role } from "discord.js";
+import { getAllMembers, iterateEnum } from "../../src/utils/iteration.utils";
+
+describe.skip("iterating over an enum", () => {
+  enum DummyEnum { A = 0, B, C }
+
+  it("should yield name-value pairs", () => {
+    const result = iterateEnum(DummyEnum);
+    // TODO: the order within each 2-tuple seems to be flipped as well!
+    expect(result).toEqual([
+      ["A", 0],
+      ["B", 1],
+      ["C", 2],
+    ]);
+  });
+});
+
+describe("resolving a mentionable to members", () => {
+  // NOTE: Can't really test the case with a lone member since `instanceof
+  // GuildMember` is used, and GuildMember's constructor is private :/
+
+  it("should resolve a role into members", () => {
+    const mockRole = {
+      members: new Collection([["m1", "dummy1"], ["m2", "dummy2"]]),
+    } as unknown as Role;
+    const result = getAllMembers(mockRole);
+    expect(result).toEqual(["dummy1", "dummy2"]);
+  });
+});

--- a/tests/utils/markdown.utils.test.ts
+++ b/tests/utils/markdown.utils.test.ts
@@ -1,0 +1,70 @@
+jest.mock("../../src/utils/dates.utils");
+
+import { toUnixSeconds } from "../../src/utils/dates.utils";
+import {
+  TimestampFormat,
+  joinUserMentions,
+  toBulletedList,
+  toChannelMention,
+  toRelativeTimestampMention,
+  toRoleMention,
+  toTimestampMention,
+  toUserMention,
+} from "../../src/utils/markdown.utils";
+
+const mockedToUnixSeconds = jest.mocked(toUnixSeconds);
+const DUMMY_UNIX_TIME = 4242424242;
+mockedToUnixSeconds.mockReturnValue(DUMMY_UNIX_TIME);
+
+describe("Discord object mention helpers", () => {
+  it("should return a correct role mention", () => {
+    const result = toRoleMention("12345");
+    expect(result).toEqual("<@&12345>");
+  });
+
+  it("should return a correct user mention", () => {
+    const result = toUserMention("12345");
+    expect(result).toEqual("<@12345>");
+  });
+
+  it("should return a correct channel mention", () => {
+    const result = toChannelMention("12345");
+    expect(result).toEqual("<#12345>");
+  });
+
+  it("should join user mentions", () => {
+    const result = joinUserMentions(["123", "456", "789"]);
+    expect(result).toEqual("<@123>, <@456>, <@789>");
+  });
+});
+
+describe("Discord timestamp helpers", () => {
+  it("should use the correct timestamp if format is omitted", () => {
+    const result = toTimestampMention(new Date());
+    expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}>`);
+  });
+
+  it("should use the correct timestamp format if specified", () => {
+    for (const formatCode of Object.values(TimestampFormat)) {
+      const result = toTimestampMention(new Date(), formatCode);
+      expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}:${formatCode}>`);
+    }
+  });
+
+  it("should use the relative timestamp format", () => {
+    const result = toRelativeTimestampMention(new Date());
+    expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}:R>`);
+  });
+});
+
+describe("other Markdown utilities", () => {
+  it("should return a bulleted list", () => {
+    const result = toBulletedList(["line1", "line2", "line3"]);
+    expect(result).toMatch(/^[*-] line1\n[*-] line2\n[*-] line3$/);
+  });
+
+  it("should return a bullet list with indentation", () => {
+    const result = toBulletedList(["line1", "line2", "line3"], 2);
+    expect(result).toMatch(/^ {4}[*-] line1\n {4}[*-] line2\n {4}[*-] line3$/);
+  });
+});

--- a/tests/utils/math.utils.test.ts
+++ b/tests/utils/math.utils.test.ts
@@ -7,7 +7,7 @@ describe("generating a random integer within a range", () => {
 
   afterEach(() => {
     jest.spyOn(global.Math, "random").mockRestore();
-  })
+  });
 
   it("should reject lower bounds that aren't integers", () => {
     expect(() => randRange(1.5, 6)).toThrow();

--- a/tests/utils/math.utils.test.ts
+++ b/tests/utils/math.utils.test.ts
@@ -1,0 +1,33 @@
+import { randRange } from "../../src/utils/math.utils";
+
+describe("generating a random integer within a range", () => {
+  beforeEach(() => {
+    jest.spyOn(global.Math, "random").mockReturnValue(0.50);
+  });
+
+  afterEach(() => {
+    jest.spyOn(global.Math, "random").mockRestore();
+  })
+
+  it("should reject lower bounds that aren't integers", () => {
+    expect(() => randRange(1.5, 6)).toThrow();
+  });
+
+  it("should reject upper bounds that aren't integers", () => {
+    expect(() => randRange(3, 4.5)).toThrow();
+  });
+
+  it("should reject lower bounds greater than upper bounds", () => {
+    expect(() => randRange(7, 2)).toThrow();
+  });
+
+  it("should return the correct number", () => {
+    const result = randRange(2, 6);
+    expect(result).toEqual(4);
+  });
+
+  it("should work even with negative numbers", () => {
+    const result = randRange(-10, -3);
+    expect(result).toEqual(-6);
+  });
+});


### PR DESCRIPTION
A burst addition to our post-#23 effort of incrementally adding tests for the existing modules.

This PR introduces unit tests for the two services so far, `LukeService` and `CxtieService`, as well as most of the `utils/` modules. The remaining util modules that don't have tests, `logging.utils.ts` and `options.utils.ts` because I didn't really see much purpose to adding tests for them. Some of the other util modules for which I *did* write tests already felt a bit redundant.

Other notable changes;
* Added `toEscapedEmoji()` helper as the counterpart to `parseCustomEmojis()`.
* Removed our custom `zip()` function since lodash provides a `zip()` function.
* Refactored our [original approach](https://stackoverflow.com/a/43532567/14226122) to mocking `Math.random()` to a [safer, better-practice approach](https://stackoverflow.com/a/57730344/14226122). The former was causing some strange Jest setup issue, something about:

```
TypeError: Cannot read properties of undefined (reading 'generatedLine')
```

Overall test coverage is starting to look quite nice.