### PR TITLE
Fix Ni not bypassing popopi cooldown

### DIFF
--- a/src/middleware/cooldown.middleware.ts
+++ b/src/middleware/cooldown.middleware.ts
@@ -132,7 +132,7 @@ export class CooldownManager {
         this.bypassers.add(uid);
       }
     } else if (this.spec.type === "user" && this.spec.overrides) {
-      for (const [uid, duration] of Object.entries(this.spec.overrides)) {
+      for (const [uid, duration] of this.spec.overrides.entries()) {
         this.durationOverrides.set(uid, duration);
       }
     }

--- a/tests/controllers/users/ni/popipo.listener.test.ts
+++ b/tests/controllers/users/ni/popipo.listener.test.ts
@@ -1,5 +1,6 @@
 jest.mock("../../../../src/utils/math.utils");
 
+import config from "../../../../src/config";
 import onPopipoSpec from "../../../../src/controllers/users/ni/popipo.listener";
 import { randRange } from "../../../../src/utils/math.utils";
 import { MockMessage } from "../../../test-utils";
@@ -19,5 +20,15 @@ describe("popipo listener", () => {
     mockRandRange.mockReturnValueOnce(4);
     await mock.simulateEvent();
     mock.expectRepliedSilentlyWith({ content: "popipopipopipopipo" });
+  });
+
+  it("should allow Ni to bypass cooldown", async () => {
+    const mock = new MockMessage(onPopipoSpec)
+      .mockContent("popipopipopipo")
+      .mockAuthor({ uid: config.NI_UID });
+    mockRandRange.mockReturnValueOnce(2);
+    await mock.simulateEvent();
+    await mock.simulateEvent();
+    expect(mock.message.reply).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
It turns out the root cause was a broader issue, so actually all features that used per-user cooldowns with duration overrides were broken. `CooldownManager#set` was incorrectly using `Object.entries()` instead of `Map#entries()` to initialize the duration overrides from user-type cooldown specs.