### PR TITLE
Fix unknown interaction error due to not awaiting

### DIFF
--- a/src/controllers/users/cxtie/set-react-chance.command.ts
+++ b/src/controllers/users/cxtie/set-react-chance.command.ts
@@ -38,7 +38,7 @@ setReactChance.execute(async (interaction) => {
   const context = formatContext(interaction);
   log.info(`${context}: set anti-Cxtie react chance to ${newProbability}.`);
 
-  interaction.reply(
+  await interaction.reply(
     "Updated anti-Cxtie react chance from " +
     `${oldProbability} to ${newProbability}.`
   );


### PR DESCRIPTION
Dump of log messages prior to unexpected bot termination:

```
[2024-01-11T10:12:23.014Z] command.runner.js debug: @***** /set-anti-cxtie-react-chance #🤖┃bot-spam: processing command.
[2024-01-11T10:12:23.015Z] set-react-chance.command.js info: @***** /set-anti-cxtie-react-chance #🤖┃bot-spam: set anti-Cxtie react chance to 0.02.
[2024-01-11T10:12:23.016Z] command.runner.js debug: @***** /set-anti-cxtie-react-chance #🤖┃bot-spam: finished command callback, success=true.
[2024-01-11T10:12:23.017Z] command.runner.js warning: @*****/set-anti-cxtie-react-chance #🤖┃bot-spam: execute didn't reply to interaction, using generic response.
[2024-01-11T10:12:23.217Z] command.runner.js debug: @***** /set-anti-cxtie-react-chance #🤖┃bot-spam: finished executing command.
C:\Users\*****\repos\yungkaiworldbot\node_modules\@discordjs\rest\dist\index.js:722
      throw new DiscordAPIError(data, "code" in data ? data.code : data.error, status, method, url, requestData);
            ^

DiscordAPIError[10062]: Unknown interaction
    at handleErrors (C:\Users\*****\repos\yungkaiworldbot\node_modules\@discordjs\rest\dist\index.js:722:13)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async BurstHandler.runRequest (C:\Users\*****\repos\yungkaiworldbot\node_modules\@discordjs\rest\dist\index.js:826:23)
    at async _REST.request (C:\Users\*****\repos\yungkaiworldbot\node_modules\@discordjs\rest\dist\index.js:1266:22)
    at async ChatInputCommandInteraction.reply (C:\Users\*****\repos\yungkaiworldbot\node_modules\discord.js\src\structures\interfaces\InteractionResponses.js:111:5) {
  requestBody: {
    files: [],
    json: {
      type: 4,
      data: {
        content: 'Updated anti-Cxtie react chance from 1 to 0.02.',
        tts: false,
        nonce: undefined,
        embeds: undefined,
        components: undefined,
        username: undefined,
        avatar_url: undefined,
        allowed_mentions: undefined,
        flags: undefined,
        message_reference: undefined,
        attachments: undefined,
        sticker_ids: undefined,
        thread_name: undefined
      }
    }
  },
  rawError: { message: 'Unknown interaction', code: 10062 },
  code: 10062,
  status: 404,
  method: 'POST',
  url: 'https://discord.com/api/v10/interactions/*****/callback'
}
```

The problem was that the `execute` callback of `/set-anti-cxtie-react-chance` wasn't `await`ing the `interaction.reply()`, causing the command runner to prematurely check that the interaction had not been replied to and use a generic response. The deferred `interaction.reply()` then executed, causing an unknown interaction error. This exception was uncaught (I presume because it wasn't part of an `await` and thus not caught by the try-catch wrapping the command execution pipeline), unexpectedly terminating the bot runtime.