### PR TITLE
Add tests for "moderation" modules

### DIFF
--- a/tests/controllers/moderation/profanity.listener.test.ts
+++ b/tests/controllers/moderation/profanity.listener.test.ts
@@ -1,0 +1,9 @@
+import profanitySpec from "../../../src/controllers/moderation/profanity.listener";
+import { GUILD_EMOJIS } from "../../../src/utils/emojis.utils";
+import { MockMessage } from "../../test-utils";
+
+it("should react with neko gun if profanity detected", async () => {
+  const mock = new MockMessage(profanitySpec).mockContent("oh fuck lol");
+  await mock.simulateEvent();
+  mock.expectReactedWith(GUILD_EMOJIS.NEKO_GUN);
+});

--- a/tests/controllers/moderation/wave.listener.test.ts
+++ b/tests/controllers/moderation/wave.listener.test.ts
@@ -1,0 +1,20 @@
+import { Message } from "discord.js";
+import waveSpec from "../../../src/controllers/moderation/wave.listener";
+import { MockMessage } from "../../test-utils";
+
+it("should wave at what looks like an introduction", async () => {
+  const mock = new MockMessage(waveSpec)
+    .mockChannel({ name: "introductions" })
+    .mockContent("hi i'm joe");
+  await mock.simulateEvent();
+  mock.expectReactedWith("👋");
+});
+
+it("should ignore messages that are replies", async () => {
+  const mock = new MockMessage(waveSpec)
+    .mockChannel({ name: "introductions" })
+    .mockContent("hi joe i'm dave")
+    .mockReference({ content: "hi i'm joe" } as Message);
+  await mock.simulateEvent();
+  mock.expectNotResponded();
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -129,24 +129,24 @@ export class MockInteraction {
   }
 }
 
-export function addMockGetter<PropertyType>(
-  obj: Record<string, any>,
-  key: string,
-  value: PropertyType,
+export function addMockGetter<ObjectType extends {}, ValueType>(
+  obj: ObjectType,
+  key: keyof ObjectType,
+  value: ValueType,
 ): void;
-export function addMockGetter<PropertyType>(
-  obj: Record<string, any>,
-  key: string,
-  getter: () => PropertyType,
+export function addMockGetter<ObjectType extends {}, ValueType>(
+  obj: ObjectType,
+  key: keyof ObjectType,
+  getter: () => ValueType,
 ): void;
 /**
  * Add a mock getter on the object. This is a workaround for jest-mock-extended
  * not supporting mocking getters yet. This can also be used to overwrite
  * read-only properties.
  */
-export function addMockGetter<ValueType>(
-  obj: Record<string, any>,
-  key: string,
+export function addMockGetter<ObjectType extends {}, ValueType>(
+  obj: ObjectType,
+  key: keyof ObjectType,
   getter: ValueType | (() => ValueType),
 ): jest.Mock<ValueType, [], any> {
   const mockGetter = jest.fn<ValueType, []>();
@@ -307,10 +307,16 @@ export class MockMessage {
    * Mock properties on the channel attached to the underlying message object.
    */
   public mockChannel(options: MockChannelOptions): this {
-    if (options.cid !== undefined)
+    if (options.cid !== undefined) {
       this.message.channel.id = options.cid;
-    if (options.name !== undefined)
-      (this.message.channel as GuildTextBasedChannel).name = options.name;
+    }
+    if (options.name !== undefined) {
+      addMockGetter(
+        this.message.channel as GuildTextBasedChannel,
+        "name",
+        options.name,
+      );
+    }
     return this;
   }
 


### PR DESCRIPTION
Add unit tests for the two modules we have under the "moderation" category so far:

* `profanity.listener.ts`: reacts with Neko L to messages containing profanity.
* `wave.listener.ts`: reacts with waving emoji to introductions in introduction channels.

Other changes:

* Fixed `MockMessage#mockChannel`. We didn't see the error before because it wasn't used until now.
* Enhanced type hinting on `addMockGetter`. Now, the `key` should have autocomplete for the property names on `obj`.