### PR TITLE
Enhance /cooldowns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@devraelfreeze/discordjs-pagination": "^2.7.6",
         "discord.js": "^14.14.1",
         "dotenv": "^16.3.1",
         "lodash": "^4.17.21",
@@ -674,6 +675,14 @@
         "colorspace": "1.1.x",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@devraelfreeze/discordjs-pagination": {
+      "version": "2.7.6",
+      "resolved": "https://registry.npmjs.org/@devraelfreeze/discordjs-pagination/-/discordjs-pagination-2.7.6.tgz",
+      "integrity": "sha512-mK0iMCWsk9CJC58AyvUGGxHzBZTJlxaXaboxSvcA85Tg3d4X9rerZj7Q6L8boeTNh5mbfil8IoLYicvz7gai/w==",
+      "dependencies": {
+        "discord.js": "^14.9.0"
       }
     },
     "node_modules/@discordjs/builders": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "typescript": "^5.3.3"
   },
   "dependencies": {
+    "@devraelfreeze/discordjs-pagination": "^2.7.6",
     "discord.js": "^14.14.1",
     "dotenv": "^16.3.1",
     "lodash": "^4.17.21",

--- a/src/controllers/dev/cooldowns/list-cooldowns.command.ts
+++ b/src/controllers/dev/cooldowns/list-cooldowns.command.ts
@@ -1,4 +1,5 @@
-import { Events, SlashCommandBuilder } from "discord.js";
+import { pagination } from "@devraelfreeze/discordjs-pagination";
+import { EmbedBuilder, Events, SlashCommandBuilder, User } from "discord.js";
 
 import { BotClient } from "../../../bot/client";
 import getLogger from "../../../logger";
@@ -21,6 +22,11 @@ import { addBroadcastOption } from "../../../utils/options.utils";
 import { listenerIdAutocomplete } from "./cooldowns.autocomplete";
 
 const log = getLogger(__filename);
+
+/**
+ * Max characters for the description attribute of a Discord embed.
+ */
+const MAX_DESCRIPTION_LENGTH = 4096;
 
 function formatStatus(now: Date, expiration: Date): string {
   if (now >= expiration)
@@ -94,6 +100,41 @@ function formatListenerCooldownDump(
   return `__**${listener.id}** Cooldown__\n${formatted}`;
 }
 
+function splitIntoEmbedPages(
+  formattedDumpEntries: string[],
+  maxCharsPerPage: number = MAX_DESCRIPTION_LENGTH,
+): EmbedBuilder[] {
+  const embeds: EmbedBuilder[] = []
+  let description = "";
+  for (const entry of formattedDumpEntries) {
+    const { length } = entry;
+    if (length > maxCharsPerPage) {
+      log.warning( // TODO: not very helpful not knowing which dump lol.
+        `a formatted cooldown dump has length ${length} > ` +
+        `${maxCharsPerPage}, cannot fit it into an embed page, skipped.`
+      );
+      continue;
+    }
+    if (description.length + length > maxCharsPerPage) {
+      const embed = new EmbedBuilder()
+        .setTitle("Cooldown States")
+        .setDescription(description.trimEnd());
+      embeds.push(embed);
+      description = "";
+    }
+    description += entry + "\n";
+  }
+
+  if (description) {
+    const embed = new EmbedBuilder()
+      .setTitle("Cooldown States")
+      .setDescription(description.trimEnd());
+    embeds.push(embed);
+  }
+
+  return embeds;
+}
+
 const listCooldowns = new CommandBuilder();
 
 const slashCommandDefinition = new SlashCommandBuilder()
@@ -129,41 +170,48 @@ listCooldowns.execute(async (interaction) => {
     return;
   }
 
-  let response = "";
+  const context = formatContext(interaction);
   const now = new Date();
 
   // Caller provided a valid ID. Provide the dump for just that one listener.
   if (listenerId) {
     const listener = listenerMap.get(listenerId)!;
-    response = formatListenerCooldownDump(now, listener);
+    await interaction.reply({
+      content: formatListenerCooldownDump(now, listener),
+      ephemeral: !broadcast,
+      allowedMentions: { parse: [] }, // Suppress mention pinging.
+    });
+    log.debug(`${context}: dumped cooldown for ${listenerId}.`);
+    return;
   }
 
   // Otherwise provide the dumps for all listeners.
-  else {
-    const listeners = Array.from(listenerMap.values());
-    const entries = listeners.map(l => formatListenerCooldownDump(now, l));
-    response = entries.join("\n");
+  const listeners = Array.from(listenerMap.values());
+  const entries = listeners
+    .filter(l => l.cooldown?.type && l.cooldown.type !== "disabled")
+    .map(l => formatListenerCooldownDump(now, l));
 
-    if (!response) {
-      response = (
+  if (entries.length === 0) {
+    await interaction.reply({
+      content:
         "The bot isn't listening for anything that could have a cooldown " +
-        "at the moment!"
-      );
-    }
+        "at the moment!",
+      ephemeral: !broadcast,
+    });
+    return;
   }
 
-  await interaction.reply({
-    content: response,
+  const pages = splitIntoEmbedPages(entries, 600);
+  await pagination({
+    // @ts-expect-error. Embed constructor is private?? And you can't get Embed
+    // from EmbedBuilder?? I think under the hood, it uses .toJSON() to get
+    // APIEmbed, so leaving it as EmbedBuilder should be fine??
+    embeds: pages,
+    author: interaction.member!.user as User,
+    interaction,
     ephemeral: !broadcast,
-    allowedMentions: { parse: [] }, // Suppress mention pinging.
   });
-
-  const context = formatContext(interaction);
-  if (listenerId) {
-    log.debug(`${context}: dumped cooldown for ${listenerId}.`);
-  } else {
-    log.debug(`${context}: dumped cooldowns.`);
-  }
+  log.debug(`${context}: dumped cooldowns.`);
 });
 
 const listCooldownsSpec = listCooldowns.toSpec();

--- a/src/controllers/dev/cooldowns/list-cooldowns.command.ts
+++ b/src/controllers/dev/cooldowns/list-cooldowns.command.ts
@@ -1,26 +1,98 @@
 import { Events, SlashCommandBuilder } from "discord.js";
 
-
 import { BotClient } from "../../../bot/client";
+import getLogger from "../../../logger";
 import {
-  RoleLevel,
-  checkPrivilege,
-} from "../../../middleware/privilege.middleware";
+  GlobalCooldownDump,
+  PerUserCooldownDump,
+} from "../../../middleware/cooldown.middleware";
 import { CommandBuilder } from "../../../types/command.types";
+import { ListenerSpec } from "../../../types/listener.types";
+import { formatHoursMinsSeconds } from "../../../utils/dates.utils";
+import { formatContext } from "../../../utils/logging.utils";
+import {
+  joinUserMentions,
+  toBulletedList,
+  toRelativeTimestampMention,
+  toTimestampMention,
+  toUserMention,
+} from "../../../utils/markdown.utils";
 import { addBroadcastOption } from "../../../utils/options.utils";
 import { listenerIdAutocomplete } from "./cooldowns.autocomplete";
 
-/**
- * Return a partial copy of the client's listener spec mapping with only the
- * listeners that are instances of `MessageListener`.
- */
-// function filterListenerMap(client: BotClient)
-//   : Collection<string, MessageListener> {
-//   return client.listenerSpecs
-//     .filter(listener => listener instanceof MessageListener)
-//     .mapValues(listener => listener as MessageListener);
-// }
+const log = getLogger(__filename);
 
+function formatStatus(now: Date, expiration: Date): string {
+  if (now >= expiration)
+    return "Inactive ✅";
+  const mention = toTimestampMention(expiration);
+  const relativeMention = toRelativeTimestampMention(expiration);
+  return `Active until ${mention} (${relativeMention}) ⌛`;
+}
+
+function formatGlobalCooldownDump(
+  now: Date,
+  dump: GlobalCooldownDump,
+): string {
+  const bypasserMentions = joinUserMentions(dump.bypassers);
+  const result = toBulletedList([
+    "**Type:** GLOBAL",
+    `**Status:** ${formatStatus(now, dump.expiration)}`,
+    `**Duration:** ${formatHoursMinsSeconds(dump.seconds)}`,
+    `**Bypassers:** ${bypasserMentions || "(none)"}`,
+  ]);
+  return result;
+}
+
+function formatPerUserCooldownDump(
+  now: Date,
+  dump: PerUserCooldownDump,
+): string {
+  const statuses: string[] = [];
+  for (const [userId, expiration] of dump.expirations.entries()) {
+    const mention = toUserMention(userId);
+    statuses.push(`${mention}: ${formatStatus(now, expiration)}`);
+  }
+  const statusesBullets = toBulletedList(statuses, 1);
+
+  const durations: string[] = [];
+  for (const [userId, duration] of dump.overrides) {
+    const mention = toUserMention(userId);
+    durations.push(`${mention}: ${formatHoursMinsSeconds(duration)}`);
+  }
+  const durationsBullets = toBulletedList(durations, 1);
+
+  const formattedDefault = formatHoursMinsSeconds(dump.defaultSeconds);
+  const result = toBulletedList([
+    "**Type:** PER-USER",
+    "**Statuses:**" + (statusesBullets
+      ? `\n${statusesBullets}`
+      : " (none)"
+    ),
+    `**Default duration:** ${formattedDefault}`,
+    "**Duration overrides:**" + (durationsBullets
+      ? `\n${durationsBullets}`
+      : " (none)"
+    ),
+  ]);
+  return result;
+}
+
+function formatListenerCooldownDump(
+  now: Date,
+  listener: ListenerSpec<Events.MessageCreate>,
+): string {
+  const dump = listener.cooldown?.dump();
+  let formatted: string;
+  if (dump) {
+    formatted = dump.type === "global"
+      ? formatGlobalCooldownDump(now, dump)
+      : formatPerUserCooldownDump(now, dump);
+  } else {
+    formatted = "(disabled)";
+  }
+  return `__**${listener.id}** Cooldown__\n${formatted}`;
+}
 
 const listCooldowns = new CommandBuilder();
 
@@ -40,8 +112,6 @@ listCooldowns.define(slashCommandDefinition);
 
 listCooldowns.autocomplete(listenerIdAutocomplete);
 
-listCooldowns.check(checkPrivilege(RoleLevel.DEV)); // TEMP.
-
 listCooldowns.execute(async (interaction) => {
   const { options } = interaction;
   const broadcast = !!options.getBoolean("broadcast");
@@ -60,20 +130,19 @@ listCooldowns.execute(async (interaction) => {
   }
 
   let response = "";
+  const now = new Date();
 
   // Caller provided a valid ID. Provide the dump for just that one listener.
   if (listenerId) {
     const listener = listenerMap.get(listenerId)!;
-    const dump = listener.cooldown?.dump() ?? "(disabled)";
-    response = `__**${listenerId}** Cooldown__\n${dump}\n`;
+    response = formatListenerCooldownDump(now, listener);
   }
+
   // Otherwise provide the dumps for all listeners.
   else {
-    for (const [id, listener] of listenerMap) {
-      const dump = listener.cooldown?.dump();
-      if (dump !== null && dump !== undefined)
-        response += `__**${id}** Cooldown__\n${dump}\n`;
-    }
+    const listeners = Array.from(listenerMap.values());
+    const entries = listeners.map(l => formatListenerCooldownDump(now, l));
+    response = entries.join("\n");
 
     if (!response) {
       response = (
@@ -88,6 +157,13 @@ listCooldowns.execute(async (interaction) => {
     ephemeral: !broadcast,
     allowedMentions: { parse: [] }, // Suppress mention pinging.
   });
+
+  const context = formatContext(interaction);
+  if (listenerId) {
+    log.debug(`${context}: dumped cooldown for ${listenerId}.`);
+  } else {
+    log.debug(`${context}: dumped cooldowns.`);
+  }
 });
 
 const listCooldownsSpec = listCooldowns.toSpec();


### PR DESCRIPTION
This PR does two things:

1. Addresses the deprecated `CooldownManager#dump` by replacing its implementation to decouple the application and presentation layer in `CooldownManager`. Before, `.dump()` was the one responsible for formatting the response to be sent back to Discord, but this shouldn't have been the responsibility of `CooldownManager`, which should only be responsible for state. The new `.dump()` thus returns an object *representing* the current state of the cooldown, and it's now the responsibility of the `/cooldowns` controller to format this data into a user-friendly response.
2. Paginates the response to `/cooldowns` when dumping ALL cooldowns (using the [discordjs-pagination](https://www.npmjs.com/package/@devraelfreeze/discordjs-pagination) package). This solves the issue mentioned in #16 where our sheer number of cooldowns cause the plain text approach to exceed the 2000 character limit.