### PR TITLE
Make branch name from /ping use one at startup

### DIFF
--- a/src/controllers/dev/ping.command.ts
+++ b/src/controllers/dev/ping.command.ts
@@ -1,4 +1,3 @@
-import child_process from "node:child_process";
 
 import {
   ChatInputCommandInteraction,
@@ -18,20 +17,6 @@ import {
 import { addBroadcastOption } from "../../utils/options.utils";
 
 const log = getLogger(__filename);
-
-function getCurrentBranchName(): string | null {
-  const command = "git rev-parse --abbrev-ref HEAD";
-  const process = child_process.spawnSync(command, { shell: true });
-  if (process.status !== 0) {
-    const stderr = process.stderr?.toString().trim();
-    log.warning(
-      `\`${command}\` failed with exit code ${process.status}` +
-      (stderr ? `: ${stderr}` : "")
-    );
-    return null;
-  }
-  return process.stdout.toString().trim();
-}
 
 const slashCommandDefinition = new SlashCommandBuilder()
   .setName("ping")
@@ -58,14 +43,15 @@ async function respondWithDevDetails(
     }
   }
 
-  const branchName = getCurrentBranchName();
-  if (branchName !== null) {
+  const { branchName, readySince } = client;
+
+  if (branchName) {
     text += `\n* Branch: \`${branchName}\``;
   }
 
-  if (client.readySince) {
-    const timestamp = toTimestampMention(client.readySince);
-    const relativeTimestamp = toRelativeTimestampMention(client.readySince);
+  if (readySince) {
+    const timestamp = toTimestampMention(readySince);
+    const relativeTimestamp = toRelativeTimestampMention(readySince);
     text += `\n* Ready: ${timestamp} (${relativeTimestamp})`;
   }
 

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -1,10 +1,12 @@
 import pingSpec from "../../../src/controllers/dev/ping.command";
-import { toRelativeTimestampMention, toTimestampMention } from "../../../src/utils/markdown.utils";
-
+import {
+  toRelativeTimestampMention,
+  toTimestampMention,
+} from "../../../src/utils/markdown.utils";
 import {
   MockInteraction,
   TestClient,
-  addMockGetter
+  addMockGetter,
 } from "../../test-utils";
 
 describe("/ping command", () => {
@@ -15,10 +17,12 @@ describe("/ping command", () => {
 
   it("should respond with latency, branch, startup details", async () => {
     const dummyPing = 42;
+    const dummyBranchName = "dummy-branch-name";
     const dummyReadySince = new Date();
 
     const mockClient = new TestClient();
     mockClient.readySince = dummyReadySince;
+    mockClient.branchName = dummyBranchName;
     addMockGetter(mockClient.ws, "ping", dummyPing);
     mock.mockClient(mockClient);
 
@@ -28,7 +32,7 @@ describe("/ping command", () => {
     const relativeTimestamp = toRelativeTimestampMention(dummyReadySince);
     const expectedParts = [
       `Latency: **${dummyPing}**`,
-      "Branch: ",
+      `Branch: \`${dummyBranchName}\``,
       `Ready: ${timestamp} (${relativeTimestamp})`,
     ];
     for (const part of expectedParts) {

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -22,7 +22,7 @@ describe("/ping command", () => {
 
     const mockClient = new TestClient();
     mockClient.readySince = dummyReadySince;
-    mockClient.branchName = dummyBranchName;
+    addMockGetter(mockClient, "branchName", dummyBranchName);
     addMockGetter(mockClient.ws, "ping", dummyPing);
     mock.mockClient(mockClient);
 


### PR DESCRIPTION
Before, since `getCurrentBranchName()` was computed at command execution time, the branch name returned would be whatever the repository happened to be checked out to, which defeats the purpose of the "Branch" field, which should describe the version of the bot currently running. Since the program is already in main memory when running, checking out the repository shouldn't affect the bot's runtime, so it should be associated with the branch at startup time and not real time.