### PR TITLE
Add/refactor misc features

### DIFF
--- a/src/controllers/dev/presence.command.ts
+++ b/src/controllers/dev/presence.command.ts
@@ -18,8 +18,9 @@ import { formatContext } from "../../utils/logging.utils";
 const log = getLogger(__filename);
 
 type Choice<T> = APIApplicationCommandOptionChoice<T>;
-type ActivityTypeName = keyof typeof ActivityType;
-type PresenceUpdateStatusName
+
+export type ActivityTypeName = keyof typeof ActivityType;
+export type PresenceUpdateStatusName
   = Exclude<keyof typeof PresenceUpdateStatus, "Offline">;
 
 const activityTypeNames: ActivityTypeName[]

--- a/src/controllers/dev/presence.command.ts
+++ b/src/controllers/dev/presence.command.ts
@@ -108,7 +108,7 @@ async function updateBotPresence(
     log.info(`${context}: set bot status to ${statusValue}.`);
   }
 
-  await interaction.reply("👍");
+  await interaction.reply({ content: "👍", ephemeral: true });
   return true;
 }
 

--- a/src/controllers/users/luke/dad-joke.listener.ts
+++ b/src/controllers/users/luke/dad-joke.listener.ts
@@ -1,7 +1,5 @@
-
-import { CooldownManager, useCooldown } from "../../../middleware/cooldown.middleware";
 import {
-  channelPollutionAllowed
+  channelPollutionAllowed,
 } from "../../../middleware/filters.middleware";
 import lukeService from "../../../services/luke.service";
 import { MessageListenerBuilder } from "../../../types/listener.types";
@@ -10,10 +8,7 @@ const dadJoker = new MessageListenerBuilder().setId("dad-joke");
 
 dadJoker.filter(channelPollutionAllowed);
 dadJoker.execute(lukeService.processDadJoke);
-
-const cooldown = new CooldownManager({ type: "user", defaultSeconds: 600 });
-dadJoker.filter(useCooldown(cooldown));
-dadJoker.saveCooldown(cooldown);
+dadJoker.cooldown({ type: "user", defaultSeconds: 600 });
 
 const dadJokeSpec = dadJoker.toSpec();
 export default dadJokeSpec;

--- a/src/controllers/users/ni/popipo.listener.ts
+++ b/src/controllers/users/ni/popipo.listener.ts
@@ -10,19 +10,21 @@ import {
 } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { replySilently } from "../../../utils/interaction.utils";
+import { formatContext } from "../../../utils/logging.utils";
 import { randRange } from "../../../utils/math.utils";
 
 const log = getLogger(__filename);
 
 const onPopipo = new MessageListenerBuilder().setId("popipo");
 
-onPopipo.filter(contentMatching(/popipo/i));
+onPopipo.filter(contentMatching(/(popipo|뽀삐뽀)/i));
 onPopipo.filter(channelPollutionAllowedOrBypass(config.NI_UID));
 
 onPopipo.execute(async (message) => {
   const randomNum = randRange(2, 6);
   const response = "popi".repeat(randomNum) + "po";
   await replySilently(message, response);
+  log.debug(`${formatContext(message)}: replied with '${response}'.`);
 });
 
 const cooldown = new CooldownManager({

--- a/src/services/luke.service.ts
+++ b/src/services/luke.service.ts
@@ -28,12 +28,19 @@ export class LukeService {
     const [_, notPresent, captured] = matches;
 
     let response: string;
+
+    // Negative version of the joke.
     if (notPresent) {
-      response = (
-        `Of course you're not ${captured}, you're ${author.displayName}!`
-      );
-    } else {
-      response = `Hi ${captured}, I'm ${message.client.user.displayName}!`;
+      response =
+        `Of course you're not ${captured}, you're ${author.displayName}!`;
+    }
+
+    // Affirmative version of the joke.
+    else {
+      if (captured.match(/^(back|awake|up|here)[.~!?-]*$/i))
+        response = `Welcome back, ${author.displayName}!`;
+      else
+        response = `Hi ${captured}, I'm ${message.client.user.displayName}!`;
     }
 
     await replySilently(message, response);

--- a/tests/controllers/dev/presence.command.test.ts
+++ b/tests/controllers/dev/presence.command.test.ts
@@ -1,104 +1,110 @@
-import { ActivityOptions, ActivityType, PresenceUpdateStatus } from "discord.js";
+import {
+  ActivityOptions,
+  ActivityType,
+  PresenceUpdateStatus,
+} from "discord.js";
+
 import config from "../../../src/config";
-import presenceSpec from "../../../src/controllers/dev/presence.command";
+import presenceSpec, {
+  ActivityTypeName,
+  PresenceUpdateStatusName,
+} from "../../../src/controllers/dev/presence.command";
 import { MockInteraction } from "../../test-utils";
 
-describe("/presence command", () => {
-  let mock: MockInteraction;
-  beforeEach(() => {
-    mock = new MockInteraction(presenceSpec);
-  })
+let mock: MockInteraction;
+beforeEach(() => {
+  mock = new MockInteraction(presenceSpec);
+});
 
-  it("should require privilege >= DEV", async () => {
-    mock.mockCallerRoles(config.KAI_RID);
-    mock.mockOption("Boolean", "clear_activity", true);
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
-    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
-    mock.expectRepliedWith({
-      // Any mention of the DEV level.
-      content: expect.stringMatching(/\bDEV\b/i),
-      ephemeral: true,
-    });
+it("should require privilege >= DEV", async () => {
+  mock.mockCallerRoles(config.KAI_RID);
+  mock.mockOption("Boolean", "clear_activity", true);
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
+  expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+  mock.expectRepliedWith({
+    // Any mention of the DEV level.
+    content: expect.stringMatching(/\bDEV\b/i),
+    ephemeral: true,
   });
+});
 
-  it("should clear the activity as long as the flag is set", async () => {
-    mock
-      .mockCallerRoles(config.BOT_DEV_RID)
-      .mockOption("Boolean", "clear_activity", true)
-      .mockOption("String", "activity_name", "unit testing!")
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith();
-    mock.expectReplied();
-  });
+it("should clear the activity as long as the flag is set", async () => {
+  mock
+    .mockCallerRoles(config.BOT_DEV_RID)
+    .mockOption("Boolean", "clear_activity", true)
+    .mockOption("String", "activity_name", "unit testing!")
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith();
+  mock.expectReplied();
+});
 
-  it("should disallow providing an activity type without a name", async () => {
-    mock.mockCallerRoles(config.BOT_DEV_RID);
-    mock.mockOption("String", "activity_type", "Listening");
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
-    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
-    mock.expectRepliedWith({
-      content: expect.stringMatching(/\bname\b/i),
-      ephemeral: true,
-    });
+it("should disallow providing an activity type without a name", async () => {
+  mock.mockCallerRoles(config.BOT_DEV_RID);
+  mock.mockOption<ActivityTypeName>("String", "activity_type", "Listening");
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
+  expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+  mock.expectRepliedWith({
+    content: expect.stringMatching(/\bname\b/i),
+    ephemeral: true,
   });
+});
 
-  it("should set the activity name if provided", async () => {
-    mock
-      .mockCallerRoles(config.BOT_DEV_RID)
-      .mockOption("String", "activity_name", "unit testing!");
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
-      expect.objectContaining<ActivityOptions>({ name: "unit testing!" }),
-    );
-    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
-    mock.expectReplied();
-  });
+it("should set the activity name if provided", async () => {
+  mock
+    .mockCallerRoles(config.BOT_DEV_RID)
+    .mockOption("String", "activity_name", "unit testing!");
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
+    expect.objectContaining<ActivityOptions>({ name: "unit testing!" }),
+  );
+  expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+  mock.expectReplied();
+});
 
-  it("should set the activity name with type if provided", async () => {
-    mock
-      .mockCallerRoles(config.BOT_DEV_RID)
-      .mockOption("String", "activity_name", "unit testing!")
-      .mockOption("String", "activity_type", "Listening");
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
-      expect.objectContaining<ActivityOptions>({
-        name: "unit testing!",
-        type: ActivityType.Listening,
-      }),
-    );
-    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
-    mock.expectReplied();
-  });
+it("should set the activity name with type if provided", async () => {
+  mock
+    .mockCallerRoles(config.BOT_DEV_RID)
+    .mockOption("String", "activity_name", "unit testing!")
+    .mockOption<ActivityTypeName>("String", "activity_type", "Listening");
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
+    expect.objectContaining<ActivityOptions>({
+      name: "unit testing!",
+      type: ActivityType.Listening,
+    }),
+  );
+  expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+  mock.expectReplied();
+});
 
-  it("should set the status if provided", async () => {
-    mock
-      .mockCallerRoles(config.BOT_DEV_RID)
-      .mockOption("String", "status", "Idle");
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setStatus).toHaveBeenLastCalledWith(
-      PresenceUpdateStatus.Idle,
-    );
-    expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
-    mock.expectReplied();
-  });
+it("should set the status if provided", async () => {
+  mock
+    .mockCallerRoles(config.BOT_DEV_RID)
+    .mockOption<PresenceUpdateStatusName>("String", "status", "Idle");
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setStatus).toHaveBeenLastCalledWith(
+    PresenceUpdateStatus.Idle,
+  );
+  expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
+  mock.expectReplied();
+});
 
-  it("should set everything if all provided", async () => {
-    mock
-      .mockCallerRoles(config.BOT_DEV_RID)
-      .mockOption("String", "status", "Idle")
-      .mockOption("String", "activity_type", "Listening")
-      .mockOption("String", "activity_name", "unit testing!");
-    await mock.simulateCommand();
-    expect(mock.interaction.client.user.setStatus).toHaveBeenLastCalledWith(
-      PresenceUpdateStatus.Idle,
-    );
-    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
-      expect.objectContaining<ActivityOptions>({
-        name: "unit testing!",
-        type: ActivityType.Listening,
-      }),
-    );
-  });
+it("should set everything if all provided", async () => {
+  mock
+    .mockCallerRoles(config.BOT_DEV_RID)
+    .mockOption<PresenceUpdateStatusName>("String", "status", "Idle")
+    .mockOption<ActivityTypeName>("String", "activity_type", "Listening")
+    .mockOption("String", "activity_name", "unit testing!");
+  await mock.simulateCommand();
+  expect(mock.interaction.client.user.setStatus).toHaveBeenLastCalledWith(
+    PresenceUpdateStatus.Idle,
+  );
+  expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
+    expect.objectContaining<ActivityOptions>({
+      name: "unit testing!",
+      type: ActivityType.Listening,
+    }),
+  );
 });

--- a/tests/controllers/dev/presence.command.test.ts
+++ b/tests/controllers/dev/presence.command.test.ts
@@ -1,0 +1,104 @@
+import { ActivityOptions, ActivityType, PresenceUpdateStatus } from "discord.js";
+import config from "../../../src/config";
+import presenceSpec from "../../../src/controllers/dev/presence.command";
+import { MockInteraction } from "../../test-utils";
+
+describe("/presence command", () => {
+  let mock: MockInteraction;
+  beforeEach(() => {
+    mock = new MockInteraction(presenceSpec);
+  })
+
+  it("should require privilege >= DEV", async () => {
+    mock.mockCallerRoles(config.KAI_RID);
+    mock.mockOption("Boolean", "clear_activity", true);
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
+    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+    mock.expectRepliedWith({
+      // Any mention of the DEV level.
+      content: expect.stringMatching(/\bDEV\b/i),
+      ephemeral: true,
+    });
+  });
+
+  it("should clear the activity as long as the flag is set", async () => {
+    mock
+      .mockCallerRoles(config.BOT_DEV_RID)
+      .mockOption("Boolean", "clear_activity", true)
+      .mockOption("String", "activity_name", "unit testing!")
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith();
+    mock.expectReplied();
+  });
+
+  it("should disallow providing an activity type without a name", async () => {
+    mock.mockCallerRoles(config.BOT_DEV_RID);
+    mock.mockOption("String", "activity_type", "Listening");
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
+    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+    mock.expectRepliedWith({
+      content: expect.stringMatching(/\bname\b/i),
+      ephemeral: true,
+    });
+  });
+
+  it("should set the activity name if provided", async () => {
+    mock
+      .mockCallerRoles(config.BOT_DEV_RID)
+      .mockOption("String", "activity_name", "unit testing!");
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
+      expect.objectContaining<ActivityOptions>({ name: "unit testing!" }),
+    );
+    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+    mock.expectReplied();
+  });
+
+  it("should set the activity name with type if provided", async () => {
+    mock
+      .mockCallerRoles(config.BOT_DEV_RID)
+      .mockOption("String", "activity_name", "unit testing!")
+      .mockOption("String", "activity_type", "Listening");
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
+      expect.objectContaining<ActivityOptions>({
+        name: "unit testing!",
+        type: ActivityType.Listening,
+      }),
+    );
+    expect(mock.interaction.client.user.setStatus).not.toHaveBeenCalled();
+    mock.expectReplied();
+  });
+
+  it("should set the status if provided", async () => {
+    mock
+      .mockCallerRoles(config.BOT_DEV_RID)
+      .mockOption("String", "status", "Idle");
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setStatus).toHaveBeenLastCalledWith(
+      PresenceUpdateStatus.Idle,
+    );
+    expect(mock.interaction.client.user.setActivity).not.toHaveBeenCalled();
+    mock.expectReplied();
+  });
+
+  it("should set everything if all provided", async () => {
+    mock
+      .mockCallerRoles(config.BOT_DEV_RID)
+      .mockOption("String", "status", "Idle")
+      .mockOption("String", "activity_type", "Listening")
+      .mockOption("String", "activity_name", "unit testing!");
+    await mock.simulateCommand();
+    expect(mock.interaction.client.user.setStatus).toHaveBeenLastCalledWith(
+      PresenceUpdateStatus.Idle,
+    );
+    expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith(
+      expect.objectContaining<ActivityOptions>({
+        name: "unit testing!",
+        type: ActivityType.Listening,
+      }),
+    );
+  });
+});

--- a/tests/controllers/users/ni/popipo.listener.test.ts
+++ b/tests/controllers/users/ni/popipo.listener.test.ts
@@ -22,6 +22,13 @@ describe("popipo listener", () => {
     mock.expectRepliedSilentlyWith({ content: "popipopipopipopipo" });
   });
 
+  it("should trigger on '뽀삐뽀' as well", async () => {
+    const mock = new MockMessage(onPopipoSpec).mockContent("뽀삐뽀뽀삐뽀");
+    mockRandRange.mockReturnValueOnce(4);
+    await mock.simulateEvent();
+    mock.expectRepliedSilentlyWith({ content: "popipopipopipopipo" });
+  });
+
   it("should allow Ni to bypass cooldown", async () => {
     const mock = new MockMessage(onPopipoSpec)
       .mockContent("popipopipopipo")

--- a/tests/services/luke.service.test.ts
+++ b/tests/services/luke.service.test.ts
@@ -66,6 +66,15 @@ describe("dad joke handler", () => {
     );
   });
 
+  it("should respond with the special 'Welcome back' version", async () => {
+    const mockMessage = getMockMessage("i am back!");
+
+    const result = await lukeService.processDadJoke(mockMessage);
+
+    expect(result).toEqual(true);
+    expectRepliedWith(mockMessage, "Welcome back, test-user!");
+  });
+
   it("should not respond if the trigger is not detected", async () => {
     const mockMessage = getMockMessage("an ordinary message");
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -97,6 +97,15 @@ export class MockInteraction {
     return this;
   }
 
+  /**
+   * ASSERT.
+   *
+   * Shorthand for expecting that the interaction has been replied to in any
+   * way.
+   */
+  public expectReplied(): void {
+    expect(this.interaction.reply).toHaveBeenCalled();
+  }
 
   /**
    * ASSERT.

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -90,10 +90,14 @@ export class MockInteraction {
    *
    * Mock an option value on this interaction.
    */
-  public mockOption(type: OptionType, name: string, value: any): this {
-    const options
-      = this.interaction.options as DeepMockProxy<CommandInteractionOptionResolver>;
-    options[`get${type}`].calledWith(name).mockReturnValue(value);
+  public mockOption<T = any>(type: OptionType, name: string, value: T): this {
+    const options = this.interaction.options as
+      DeepMockProxy<CommandInteractionOptionResolver>;
+    // NOTE: For SOME reason, mockReturnValue is always expecting an argument of
+    // type null even though the option getter can return other values. `as
+    // null` is to pacify this TS error when switching param value from `any` to
+    // `T`. Code still works as expected.
+    options[`get${type}`].calledWith(name).mockReturnValue(value as null);
     return this;
   }
 


### PR DESCRIPTION
## Changelog

* Made the `popipo` listener trigger on Korean "뽀삐뽀" too.
* Made the `/presence` response always ephemeral.
* Added a "Welcome back" variant of the Dad joke that triggers when someone says something like "I'm back", "I'm awake", etc.


## Internal Changelog

* Ported tests for `/presence` from an unfinished branch attempting to write tests for remaining existing commands following #23.
* Added optional type parameter to `MockInteraction#mockOption` to constrain the type for the `value` argument for better type checking.
