### PR TITLE
Set up linting with ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,12 +13,17 @@
     "sourceType": "module"
   },
   "plugins": [
-    "@typescript-eslint"
+    "@typescript-eslint",
+    "import-newlines"
   ],
   "rules": {
     "indent": [
       "error",
-      2
+      2,
+      {
+        "SwitchCase": 1,
+        "ImportDeclaration": 1
+      }
     ],
     "linebreak-style": [
       "error",
@@ -57,6 +62,7 @@
       "multi-line",
       "consistent"
     ],
+    "nonblock-statement-body-position": "error",
     "dot-location": [
       "error",
       "property"
@@ -76,9 +82,7 @@
       }
     ],
     "no-console": "off",
-    "no-empty-function": "error",
     "no-floating-decimal": "error",
-    "no-inline-comments": "error",
     "no-lonely-if": "error",
     "no-multi-spaces": "error",
     "no-multiple-empty-lines": [
@@ -89,7 +93,11 @@
         "maxBOF": 0
       }
     ],
-    "no-shadow": [
+    // NOTE: The default no-shadow for some reason reports enums as "already
+    // declared in the upper scope." The fix via @typescript/eslint's version
+    // comes from: https://stackoverflow.com/a/63961972/14226122
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": [
       "error",
       {
         "allow": [
@@ -112,7 +120,6 @@
     "space-before-function-paren": [
       "error",
       {
-        "anonymous": "never",
         "named": "never",
         "asyncArrow": "always"
       }
@@ -122,6 +129,23 @@
     "space-unary-ops": "error",
     "spaced-comment": "error",
     "yoda": "error",
+    "max-len": [
+      "warn",
+      {
+        "code": 80,
+        "ignoreComments": false,
+        // Exempt default imports (can't do much about that). This regexp
+        // actually exempts all import statements, but the import-newlines
+        // plugin will catch named imports that exceed max-len.
+        "ignorePattern": "^import [^\\n\\r]*? from \".+\"\\s*;$"
+      }
+    ],
+    "import-newlines/enforce": [
+      "error",
+      {
+        "max-len": 80
+      }
+    ],
     // Use explicit any with care, but still allow for special circumstances.
     "@typescript-eslint/no-explicit-any": "off"
   }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,128 @@
+{
+  "env": {
+    "es2021": true,
+    "node": true
+  },
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": "latest",
+    "sourceType": "module"
+  },
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "rules": {
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "double"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "arrow-spacing": [
+      "warn",
+      {
+        "before": true,
+        "after": true
+      }
+    ],
+    "brace-style": [
+      "error",
+      "stroustrup",
+      {
+        "allowSingleLine": true
+      }
+    ],
+    "comma-dangle": [
+      "error",
+      "always-multiline"
+    ],
+    "comma-spacing": "error",
+    "comma-style": "error",
+    "curly": [
+      "error",
+      "multi-line",
+      "consistent"
+    ],
+    "dot-location": [
+      "error",
+      "property"
+    ],
+    "handle-callback-err": "off",
+    "keyword-spacing": "error",
+    "max-nested-callbacks": [
+      "error",
+      {
+        "max": 4
+      }
+    ],
+    "max-statements-per-line": [
+      "error",
+      {
+        "max": 2
+      }
+    ],
+    "no-console": "off",
+    "no-empty-function": "error",
+    "no-floating-decimal": "error",
+    "no-inline-comments": "error",
+    "no-lonely-if": "error",
+    "no-multi-spaces": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 2,
+        "maxEOF": 1,
+        "maxBOF": 0
+      }
+    ],
+    "no-shadow": [
+      "error",
+      {
+        "allow": [
+          "err",
+          "resolve",
+          "reject"
+        ]
+      }
+    ],
+    "no-trailing-spaces": [
+      "error"
+    ],
+    "no-var": "error",
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "prefer-const": "error",
+    "space-before-blocks": "error",
+    "space-before-function-paren": [
+      "error",
+      {
+        "anonymous": "never",
+        "named": "never",
+        "asyncArrow": "always"
+      }
+    ],
+    "space-in-parens": "error",
+    "space-infix-ops": "error",
+    "space-unary-ops": "error",
+    "spaced-comment": "error",
+    "yoda": "error",
+    // Use explicit any with care, but still allow for special circumstances.
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,4 +1,4 @@
-name: Run Tests on Pull Request
+name: Run Checks on Pull Request
 
 on:
   pull_request_target:
@@ -44,3 +44,6 @@ jobs:
 
       - name: Run Jest tests
         run: npm test
+
+      - name: Run linter
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -97,15 +97,17 @@ environment variable names, we use this suffix convention:
 
 ### package.json Scripts
 
-| Shell Command   | Description                                                                                  |
-| --------------- | -------------------------------------------------------------------------------------------- |
-| `npm run dev`   | Start the bot runtime. This interprets the TypeScript source directly for fastest startup.   |
-| `npm run sync`  | Deploy application commands to Discord's backend. This does not start the bot runtime.       |
-| `npm run clean` | Clear JavaScript build files.                                                                |
-| `npm run build` | Compile TypeScript source to JavaScript.                                                     |
-| `npm start`     | Start the bot runtime. This invokes Node.js on the compiled JavaScript ready for production. |
-| `npm test`      | Run tests.                                                                                   |
-| `npm run now`   | Run existing JavaScript build files right away.                                              |
+| Shell Command      | Description                                                                                  |
+| ------------------ | -------------------------------------------------------------------------------------------- |
+| `npm run dev`      | Start the bot runtime. This interprets the TypeScript source directly for fastest startup.   |
+| `npm run sync`     | Deploy application commands to Discord's backend. This does not start the bot runtime.       |
+| `npm run clean`    | Clear JavaScript build files.                                                                |
+| `npm run build`    | Compile TypeScript source to JavaScript.                                                     |
+| `npm start`        | Start the bot runtime. This invokes Node.js on the compiled JavaScript ready for production. |
+| `npm run now`      | Run existing JavaScript build files right away.                                              |
+| `npm test`         | Run tests.                                                                                   |
+| `npm run lint`     | Run the linter to report errors/warnings.                                                    |
+| `npm run lint:fix` | Run the linter and fix all fixable errors in-place.                                          |
 
 
 ### Command Registration vs. Bot Runtime

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,23 +6,24 @@
 import type { Config } from "jest";
 
 const config: Config = {
-  // All imported modules in your tests should be mocked automatically
-  // automock: false,
+  // All imported modules in your tests should be mocked automatically automock:
+  // false,
 
-  // Stop running tests after `n` failures
-  // bail: 0,
+  // Stop running tests after `n` failures bail: 0,
 
   // The directory where Jest should store its cached dependency information
   // cacheDirectory: "C:\\Users\\vinlin\\AppData\\Local\\Temp\\jest",
 
-  // Automatically clear mock calls, instances, contexts and results before every test
+  // Automatically clear mock calls, instances, contexts and results before
+  // every test
   clearMocks: true,
 
-  // Indicates whether the coverage information should be collected while executing the test
+  // Indicates whether the coverage information should be collected while
+  // executing the test
   collectCoverage: true,
 
-  // An array of glob patterns indicating a set of files for which coverage information should be collected
-  // collectCoverageFrom: undefined,
+  // An array of glob patterns indicating a set of files for which coverage
+  // information should be collected collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
@@ -38,65 +39,55 @@ const config: Config = {
 
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: [
-    "text",         // Display coverage table in stdout
-    "lcov",         // Generate HTML report for visualizing (un)covered code
+    "text", // Display coverage table in stdout
+    "lcov", // Generate HTML report for visualizing (un)covered code
     "json-summary", // Generate JSON data useful for scripting
   ],
 
-  // An object that configures minimum threshold enforcement for coverage results
-  // coverageThreshold: undefined,
+  // An object that configures minimum threshold enforcement for coverage
+  // results coverageThreshold: undefined,
 
-  // A path to a custom dependency extractor
-  // dependencyExtractor: undefined,
+  // A path to a custom dependency extractor dependencyExtractor: undefined,
 
   // Make calling deprecated APIs throw helpful error messages
   // errorOnDeprecated: false,
 
-  // The default configuration for fake timers
-  // fakeTimers: {
-  //   "enableGlobally": false
+  // The default configuration for fake timers fakeTimers: { "enableGlobally":
+  // false
   // },
 
-  // Force coverage collection from ignored files using an array of glob patterns
-  // forceCoverageMatch: [],
+  // Force coverage collection from ignored files using an array of glob
+  // patterns forceCoverageMatch: [],
 
-  // A path to a module which exports an async function that is triggered once before all test suites
-  // globalSetup: undefined,
+  // A path to a module which exports an async function that is triggered once
+  // before all test suites globalSetup: undefined,
 
-  // A path to a module which exports an async function that is triggered once after all test suites
-  // globalTeardown: undefined,
+  // A path to a module which exports an async function that is triggered once
+  // after all test suites globalTeardown: undefined,
 
-  // A set of global variables that need to be available in all test environments
-  // globals: {},
+  // A set of global variables that need to be available in all test
+  // environments globals: {},
 
-  // The maximum amount of workers used to run your tests. Can be specified as % or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
+  // The maximum amount of workers used to run your tests. Can be specified as %
+  // or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as
+  // the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
   // maxWorkers: "50%",
 
-  // An array of directory names to be searched recursively up from the requiring module's location
-  // moduleDirectories: [
-  //   "node_modules"
+  // An array of directory names to be searched recursively up from the
+  // requiring module's location moduleDirectories: [ "node_modules"
   // ],
 
-  // An array of file extensions your modules use
-  // moduleFileExtensions: [
-  //   "js",
-  //   "mjs",
-  //   "cjs",
-  //   "jsx",
-  //   "ts",
-  //   "tsx",
-  //   "json",
-  //   "node"
+  // An array of file extensions your modules use moduleFileExtensions: [ "js",
+  // "mjs", "cjs", "jsx", "ts", "tsx", "json", "node"
   // ],
 
-  // A map from regular expressions to module names or to arrays of module names that allow to stub out resources with a single module
-  // moduleNameMapper: {},
+  // A map from regular expressions to module names or to arrays of module names
+  // that allow to stub out resources with a single module moduleNameMapper: {},
 
-  // An array of regexp pattern strings, matched against all module paths before considered 'visible' to the module loader
-  // modulePathIgnorePatterns: [],
+  // An array of regexp pattern strings, matched against all module paths before
+  // considered 'visible' to the module loader modulePathIgnorePatterns: [],
 
-  // Activates notifications for test results
-  // notify: false,
+  // Activates notifications for test results notify: false,
 
   // An enum that specifies notification mode. Requires { notify: true }
   // notifyMode: "failure-change",
@@ -104,20 +95,17 @@ const config: Config = {
   // A preset that is used as a base for Jest's configuration
   preset: "ts-jest",
 
-  // Run tests from one or more projects
-  // projects: undefined,
+  // Run tests from one or more projects projects: undefined,
 
-  // Use this configuration option to add custom reporters to Jest
-  // reporters: undefined,
+  // Use this configuration option to add custom reporters to Jest reporters:
+  // undefined,
 
-  // Automatically reset mock state before every test
-  // resetMocks: false,
+  // Automatically reset mock state before every test resetMocks: false,
 
-  // Reset the module registry before running each individual test
-  // resetModules: false,
+  // Reset the module registry before running each individual test resetModules:
+  // false,
 
-  // A path to a custom resolver
-  // resolver: undefined,
+  // A path to a custom resolver resolver: undefined,
 
   // Automatically restore mock state and implementation before every test
   // restoreMocks: false,
@@ -126,42 +114,39 @@ const config: Config = {
   rootDir: "./",
 
   // A list of paths to directories that Jest should use to search for files in
-  // roots: [
-  //   "<rootDir>"
+  // roots: [ "<rootDir>"
   // ],
 
   // Allows you to use a custom runner instead of Jest's default test runner
   // runner: "jest-runner",
 
-  // The paths to modules that run some code to configure or set up the testing environment before each test
-  // setupFiles: [],
+  // The paths to modules that run some code to configure or set up the testing
+  // environment before each test setupFiles: [],
 
-  // A list of paths to modules that run some code to configure or set up the testing framework before each test
-  // setupFilesAfterEnv: [],
+  // A list of paths to modules that run some code to configure or set up the
+  // testing framework before each test setupFilesAfterEnv: [],
 
-  // The number of seconds after which a test is considered as slow and reported as such in the results.
-  // slowTestThreshold: 5,
+  // The number of seconds after which a test is considered as slow and reported
+  // as such in the results. slowTestThreshold: 5,
 
-  // A list of paths to snapshot serializer modules Jest should use for snapshot testing
-  // snapshotSerializers: [],
+  // A list of paths to snapshot serializer modules Jest should use for snapshot
+  // testing snapshotSerializers: [],
 
   // The test environment that will be used for testing
   testEnvironment: "node",
 
-  // Options that will be passed to the testEnvironment
-  // testEnvironmentOptions: {},
+  // Options that will be passed to the testEnvironment testEnvironmentOptions:
+  // {},
 
-  // Adds a location field to test results
-  // testLocationInResults: false,
+  // Adds a location field to test results testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
     "<rootDir>/tests/**/*.test.ts",
   ],
 
-  // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "\\\\node_modules\\\\"
+  // An array of regexp pattern strings that are matched against all test paths,
+  // matched tests are skipped testPathIgnorePatterns: [ "\\\\node_modules\\\\"
   // ],
 
   // The regexp pattern or array of patterns that Jest uses to detect test files
@@ -170,8 +155,8 @@ const config: Config = {
   // This option allows the use of a custom results processor
   // testResultsProcessor: undefined,
 
-  // This option allows use of a custom test runner
-  // testRunner: "jest-circus/runner",
+  // This option allows use of a custom test runner testRunner:
+  // "jest-circus/runner",
 
   // A map from regular expressions to paths to transformers
   transform: {
@@ -180,23 +165,22 @@ const config: Config = {
     }],
   },
 
-  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  // transformIgnorePatterns: [
-  //   "\\\\node_modules\\\\",
-  //   "\\.pnp\\.[^\\\\]+$"
+  // An array of regexp pattern strings that are matched against all source file
+  // paths, matched files will skip transformation transformIgnorePatterns: [
+  // "\\\\node_modules\\\\", "\\.pnp\\.[^\\\\]+$"
   // ],
 
-  // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
+  // An array of regexp pattern strings that are matched against all modules
+  // before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run
   // verbose: undefined,
 
-  // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
-  // watchPathIgnorePatterns: [],
+  // An array of regexp patterns that are matched against all source file paths
+  // before re-running tests in watch mode watchPathIgnorePatterns: [],
 
-  // Whether to use watchman for file crawling
-  // watchman: true,
+  // Whether to use watchman for file crawling watchman: true,
 };
 
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
         "eslint": "^8.56.0",
+        "eslint-plugin-import-newlines": "^1.3.4",
         "jest": "^29.7.0",
         "jest-mock-extended": "^3.0.5",
         "ts-jest": "^29.1.1",
@@ -2783,6 +2784,21 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-import-newlines": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-newlines/-/eslint-plugin-import-newlines-1.3.4.tgz",
+      "integrity": "sha512-Lmf/BbK+EQKUfjKPcZpslE/KTGYlgaI8ZJ/sYzdbb3BVTg5+GmLBLHBjsUKNEVRM1SEhDTF/didtOSYKi4tSnQ==",
+      "dev": true,
+      "bin": {
+        "import-linter": "lib/index.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,11 +25,23 @@
         "@types/jest": "^29.5.11",
         "@types/lodash": "^4.14.202",
         "@types/node": "^20.10.5",
+        "@typescript-eslint/eslint-plugin": "^6.18.1",
+        "@typescript-eslint/parser": "^6.18.1",
+        "eslint": "^8.56.0",
         "jest": "^29.7.0",
         "jest-mock-extended": "^3.0.5",
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      }
+    },
+    "node_modules/@aashutoshrathi/word-wrap": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -783,6 +795,89 @@
         "node": ">=18"
       }
     },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+      "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/@fastify/busboy": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.0.tgz",
@@ -790,6 +885,39 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
+      "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -1264,6 +1392,41 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.1.tgz",
@@ -1427,6 +1590,12 @@
         "pretty-format": "^29.0.0"
       }
     },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.202",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
@@ -1440,6 +1609,12 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A==",
+      "dev": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
@@ -1475,6 +1650,325 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.18.1.tgz",
+      "integrity": "sha512-nISDRYnnIpk7VCFrGcu1rnZfM1Dh9LRHnfgdkjcbi/l7g16VYRri3TjXi9Ir4lOZSw5N/gnV/3H7jIPQ8Q4daA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/type-utils": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.18.1.tgz",
+      "integrity": "sha512-zct/MdJnVaRRNy9e84XnVtRv9Vf91/qqe+hZJtKanjojud4wAVy/7lXxJmMyX6X6J+xc6c//YEWvpeif8cAhWA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.18.1.tgz",
+      "integrity": "sha512-BgdBwXPFmZzaZUuw6wKiHKIovms97a7eTImjkXCZE04TGHysG+0hDQPmygyvgtkoB/aOQwSM/nWv3LzrOIQOBw==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.18.1.tgz",
+      "integrity": "sha512-wyOSKhuzHeU/5pcRDP2G2Ndci+4g653V43gXTpt4nbyoIOAASkGDA9JIAgbQCdCkcr1MvpSYWzxTz0olCn8+/Q==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "@typescript-eslint/utils": "6.18.1",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.18.1.tgz",
+      "integrity": "sha512-4TuMAe+tc5oA7wwfqMtB0Y5OrREPF1GeJBAjqwgZh1lEMH5PJQgWgHGfYufVB51LtjD+peZylmeyxUXPfENLCw==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.18.1.tgz",
+      "integrity": "sha512-fv9B94UAhywPRhUeeV/v+3SBDvcPiLxRZJw/xZeeGgRLQZ6rLMG+8krrJUyIf6s1ecWTzlsbp0rlw7n9sjufHA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/visitor-keys": "6.18.1",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.18.1.tgz",
+      "integrity": "sha512-zZmTuVZvD1wpoceHvoQpOiewmWu3uP9FuTWo8vqpy2ffsmfCE8mklRPi+vmnIYAIk9t/4kOThri2QCDgor+OpQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.18.1",
+        "@typescript-eslint/types": "6.18.1",
+        "@typescript-eslint/typescript-estree": "6.18.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/semver": {
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.18.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.18.1.tgz",
+      "integrity": "sha512-/kvt0C5lRqGoCfsbmm7/CwMqoSkY3zzHLIjdhHZQW3VFrnz7ATecOHR7nb7V+xn4286MBxfnQfQhAmCI0u+bJA==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.18.1",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
     "node_modules/@vladfrangu/async_event_emitter": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.4.tgz",
@@ -1496,6 +1990,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
     "node_modules/acorn-walk": {
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.1.tgz",
@@ -1503,6 +2006,22 @@
       "dev": true,
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/ansi-escapes": {
@@ -1580,6 +2099,21 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/async": {
       "version": "3.2.5",
@@ -1698,6 +2232,16 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "node_modules/braces": {
       "version": "3.0.2",
@@ -2015,6 +2559,12 @@
         }
       }
     },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2051,6 +2601,18 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/discord-api-types": {
       "version": "0.37.61",
       "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.61.tgz",
@@ -2078,6 +2640,18 @@
       },
       "engines": {
         "node": ">=16.11.0"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/dotenv": {
@@ -2144,6 +2718,145 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -2155,6 +2868,48 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
+      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/execa": {
@@ -2210,11 +2965,54 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+      "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
       "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.16.0.tgz",
+      "integrity": "sha512-ifCoaXsDrsdkWTtiNJX5uzHDsrck5TzfKKDcuFFTIrrc/BS076qgEIfoIy1VeZqViznfKiysPYTh/QeHtnIsYA==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
@@ -2229,6 +3027,18 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
       "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw=="
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
     },
     "node_modules/file-stream-rotator": {
       "version": "0.6.1",
@@ -2249,6 +3059,42 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
+      "dev": true
     },
     "node_modules/fn.name": {
       "version": "1.1.0",
@@ -2343,26 +3189,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
       "dev": true,
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "is-glob": "^4.0.3"
       },
       "engines": {
-        "node": "*"
+        "node": ">=10.13.0"
       }
     },
     "node_modules/globals": {
@@ -2374,10 +3210,36 @@
         "node": ">=4"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
     "node_modules/has-flag": {
@@ -2414,6 +3276,40 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.0.tgz",
+      "integrity": "sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/import-local": {
@@ -2476,6 +3372,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -2494,6 +3399,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2501,6 +3418,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-stream": {
@@ -3252,6 +4178,18 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3264,10 +4202,28 @@
         "node": ">=4"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
     "node_modules/json5": {
@@ -3280,6 +4236,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/kleur": {
@@ -3305,11 +4270,39 @@
         "node": ">=6"
       }
     },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -3320,6 +4313,12 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
+      "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
     "node_modules/lodash.snakecase": {
@@ -3426,6 +4425,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
@@ -3446,6 +4454,18 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/moment": {
@@ -3548,6 +4568,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/optionator": {
+      "version": "0.9.3",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
+      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+      "dev": true,
+      "dependencies": {
+        "@aashutoshrathi/word-wrap": "^1.2.3",
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3563,11 +4600,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-try": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
       "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
       "engines": {
         "node": ">=6"
       }
@@ -3627,6 +4691,15 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.0.0",
@@ -3719,6 +4792,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -3758,6 +4840,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
@@ -3771,6 +4862,26 @@
         {
           "type": "opencollective",
           "url": "https://opencollective.com/fast-check"
+        }
+      ]
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
         }
       ]
     },
@@ -3847,6 +4958,54 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -4107,32 +5266,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
       "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
     },
     "node_modules/tmpl": {
       "version": "1.0.5",
@@ -4167,6 +5310,18 @@
       "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
       "engines": {
         "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
+      "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=16.13.0"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/ts-essentials": {
@@ -4316,6 +5471,18 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
@@ -4394,6 +5561,15 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "start": "npm run build && node .",
     "now": "LOGGER_LEVEL=debug node .",
-    "test": "jest"
+    "test": "jest",
+    "lint": "eslint --ext .ts .",
+    "lint:fix": "npm run lint -- --fix"
   },
   "keywords": [],
   "author": {
@@ -22,6 +24,9 @@
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.14.202",
     "@types/node": "^20.10.5",
+    "@typescript-eslint/eslint-plugin": "^6.18.1",
+    "@typescript-eslint/parser": "^6.18.1",
+    "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "jest-mock-extended": "^3.0.5",
     "ts-jest": "^29.1.1",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
     "eslint": "^8.56.0",
+    "eslint-plugin-import-newlines": "^1.3.4",
     "jest": "^29.7.0",
     "jest-mock-extended": "^3.0.5",
     "ts-jest": "^29.1.1",

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -46,10 +46,12 @@ export class BotClient extends IClientWithIntentsAndRunners {
     try {
       this.registerListeners();
       return true;
-    } catch (error) {
+    }
+    catch (error) {
       if (error instanceof DuplicateListenerIDError) {
         log.error(`duplicate listener ID: ${error.duplicateId}`);
-      } else {
+      }
+      else {
         log.crit(`unexpected error in registering events: ${error}`);
         console.error(error);
       }
@@ -66,7 +68,7 @@ export class BotClient extends IClientWithIntentsAndRunners {
 
     try {
       log.info(
-        `started refreshing ${commandsJSON.length} application (/) commands.`
+        `started refreshing ${commandsJSON.length} application (/) commands.`,
       );
 
       // The put method is used to fully refresh all commands in the guild with
@@ -77,9 +79,10 @@ export class BotClient extends IClientWithIntentsAndRunners {
       ) as unknown[];
 
       log.info(
-        `successfully reloaded ${data.length} application (/) commands.`
+        `successfully reloaded ${data.length} application (/) commands.`,
       );
-    } catch (error) {
+    }
+    catch (error) {
       log.crit("failed to refresh application commands.");
       console.error(error);
     }

--- a/src/bot/command.loader.ts
+++ b/src/bot/command.loader.ts
@@ -37,7 +37,7 @@ export class CommandLoader {
         commandPaths.push(fullPath);
         log.debug(
           "discovered command implementation file: " +
-          `${path.relative(this.commandsBaseDirectoryPath, fullPath)}.`
+          `${path.relative(this.commandsBaseDirectoryPath, fullPath)}.`,
         );
         continue;
       }
@@ -59,6 +59,7 @@ export class CommandLoader {
     const commandPaths = this.discoverCommandFiles();
 
     for (const fullPath of commandPaths) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const commandSpec = require(fullPath).default as unknown;
       const validationError = this.validateImport(commandSpec);
       if (validationError) {

--- a/src/bot/command.runner.ts
+++ b/src/bot/command.runner.ts
@@ -47,7 +47,7 @@ export class CommandRunner {
     if (!interaction.replied) {
       log.warning(
         `${context}: execute didn't reply to interaction, ` +
-        "using generic response."
+        "using generic response.",
       );
       await interaction.reply({ content: "👍", ephemeral: true });
     }
@@ -77,7 +77,8 @@ export class CommandRunner {
     const runFailHandler = async (onFail: CommandCheckFailHandler) => {
       try {
         await onFail(interaction);
-      } catch (error) {
+      }
+      catch (error) {
         log.error(`${context}: error in check fail handler.`);
         await this.handleCommandError(interaction, error as Error);
       }
@@ -89,7 +90,8 @@ export class CommandRunner {
       let checkPassed;
       try {
         checkPassed = await predicate(interaction);
-      } catch (error) {
+      }
+      catch (error) {
         log.error(`${context}: check (position ${index}) errored.`);
         await this.handleCommandError(interaction, error as Error);
         return false; // Short-circuit.
@@ -116,7 +118,8 @@ export class CommandRunner {
       // Commands that decide not to return a flag treated as always succeeding.
       success = flag ?? true;
       log.debug(`${context}: finished command callback, success=${success}.`);
-    } catch (error) {
+    }
+    catch (error) {
       log.error(`${context}: error in command execute callback.`);
       await this.handleCommandError(interaction, error as Error);
       return false;
@@ -136,9 +139,10 @@ export class CommandRunner {
       if (!afterExecute) continue;
       try {
         await afterExecute(interaction);
-      } catch (error) {
+      }
+      catch (error) {
         log.error(
-          `${context}: command post-execute hook (position ${index}) errored.`
+          `${context}: command post-execute hook (position ${index}) errored.`,
         );
         await this.handleCommandError(interaction, error as Error);
         // DON'T short-circuit. Since the execute callback succeeded, give all
@@ -158,7 +162,8 @@ export class CommandRunner {
         content: "There was an error while executing this command!",
         ephemeral: true,
       });
-    } else {
+    }
+    else {
       await interaction.reply({
         content: "There was an error while executing this command!",
         ephemeral: true,

--- a/src/bot/listener.loader.ts
+++ b/src/bot/listener.loader.ts
@@ -53,7 +53,7 @@ export class ListenerLoader {
         listenerPaths.push(fullPath);
         log.debug(
           "discovered event listener implementation file: " +
-          `${path.relative(this.listenersBaseDirectoryPath, fullPath)}.`
+          `${path.relative(this.listenersBaseDirectoryPath, fullPath)}.`,
         );
         continue;
       }
@@ -77,6 +77,7 @@ export class ListenerLoader {
     const listenerPaths = [...specialListenerPaths, ...customListenerPaths];
 
     for (const fullPath of listenerPaths) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
       const listenerSpec = require(fullPath).default as unknown;
       const validationError = this.validateImport(listenerSpec);
       if (validationError) {

--- a/src/bot/listener.runner.ts
+++ b/src/bot/listener.runner.ts
@@ -37,7 +37,7 @@ export class ListenerRunner<Type extends keyof ClientEvents> {
     await this.runFilters(...args)
       && await this.runCallback(...args)
       && await this.runCleanups(...args);
-  };
+  }
 
   protected async runFilters(...args: ClientEvents[Type]): Promise<boolean> {
     if (!this.spec.filters) return true;
@@ -48,10 +48,11 @@ export class ListenerRunner<Type extends keyof ClientEvents> {
       try {
         const passed = await predicate(...args);
         if (passed) continue;
-      } catch (error) {
+      }
+      catch (error) {
         log.error(
           `error in predicate of ${this.spec.id} listener filter` +
-          `(position ${index}), counting as failure.`
+          `(position ${index}), counting as failure.`,
         );
         this.handleListenerError(error as Error);
         return false;
@@ -61,10 +62,11 @@ export class ListenerRunner<Type extends keyof ClientEvents> {
       if (onFail) {
         try {
           await onFail(...args);
-        } catch (error) {
+        }
+        catch (error) {
           log.error(
             `error in fail handler of ${this.spec.id} listener filter ` +
-            `(position ${index}).`
+            `(position ${index}).`,
           );
           this.handleListenerError(error as Error);
         }
@@ -79,7 +81,8 @@ export class ListenerRunner<Type extends keyof ClientEvents> {
       const success = await this.spec.execute(...args);
       // Listeners that decide not to return a flag treated as always success.
       return success ?? true;
-    } catch (error) {
+    }
+    catch (error) {
       log.error(`error in ${this.spec.id} listener callback.`);
       this.handleListenerError(error as Error);
       return false;
@@ -94,7 +97,8 @@ export class ListenerRunner<Type extends keyof ClientEvents> {
       if (!afterExecute) continue;
       try {
         await afterExecute(...args);
-      } catch (error) {
+      }
+      catch (error) {
         log.error(`listener post-execute hook (position ${index}) errored.`);
         await this.handleListenerError(error as Error);
         // DON'T short circuit. Since the execute callback succeeded, give all

--- a/src/bot/listeners/command.listener.ts
+++ b/src/bot/listeners/command.listener.ts
@@ -13,8 +13,9 @@ import { BotClient } from "../client";
 const log = getLogger(__filename);
 
 async function dispatchCommand(interaction: Interaction): Promise<void> {
-  if (!interaction.isChatInputCommand() && !interaction.isAutocomplete())
+  if (!interaction.isChatInputCommand() && !interaction.isAutocomplete()) {
     return;
+  }
 
   const client = interaction.client as BotClient;
   const commandName = interaction.commandName;
@@ -28,14 +29,17 @@ async function dispatchCommand(interaction: Interaction): Promise<void> {
   if (interaction.isChatInputCommand()) {
     try {
       await runner.run(interaction);
-    } catch (error) {
+    }
+    catch (error) {
       log.crit("unexpected error in command dispatch pipeline.");
       console.error(error);
     }
-  } else if (interaction.isAutocomplete()) {
+  }
+  else if (interaction.isAutocomplete()) {
     try {
       await runner.resolveAutocomplete(interaction);
-    } catch (error) {
+    }
+    catch (error) {
       log.crit("unexpected error in autocomplete dispatch pipeline.");
       console.error(error);
     }

--- a/src/controllers/convenience/countdown.command.ts
+++ b/src/controllers/convenience/countdown.command.ts
@@ -27,7 +27,7 @@ const slashCommandDefinition = new SlashCommandBuilder()
   .addStringOption(input => input
     .setName("duration")
     .setDescription("Duration to count down from e.g. \"10s\".")
-    .setRequired(true)
+    .setRequired(true),
   );
 addEphemeralOption(slashCommandDefinition);
 
@@ -66,12 +66,12 @@ async function startCountdown(
     await interaction.channel!.send(`${mention}, your countdown has expired!`);
   }, seconds * 1000);
   log.info(
-    `${context}: set timeout for ${seconds} seconds (ends at ${endTimestamp}).`
+    `${context}: set timeout for ${seconds} seconds (ends at ${endTimestamp}).`,
   );
 
   const response =
     `Counting down to ${formatHoursMinsSeconds(seconds)} from now. ` +
-    `Expiring ${toRelativeTimestampMention(endTimestamp)}...`
+    `Expiring ${toRelativeTimestampMention(endTimestamp)}...`;
   await interaction.reply({ content: response, ephemeral });
 }
 

--- a/src/controllers/dev/cooldowns/cooldowns.autocomplete.ts
+++ b/src/controllers/dev/cooldowns/cooldowns.autocomplete.ts
@@ -9,7 +9,7 @@ export async function listenerIdAutocomplete(
 
   const listenersMap = client.getListenerSpecs(Events.MessageCreate);
   const listenersWithCD = listenersMap.filter(
-    l => l.cooldown && l.cooldown.type !== "disabled"
+    l => l.cooldown && l.cooldown.type !== "disabled",
   );
   const choiceObjs = listenersWithCD
     .filter(({ id }) => id.startsWith(focusedValue))

--- a/src/controllers/dev/cooldowns/list-cooldowns.command.ts
+++ b/src/controllers/dev/cooldowns/list-cooldowns.command.ts
@@ -32,8 +32,7 @@ const log = getLogger(__filename);
 const MAX_DESCRIPTION_LENGTH = 4096;
 
 function formatStatus(now: Date, expiration: Date): string {
-  if (now >= expiration)
-    return "Inactive ✅";
+  if (now >= expiration) return "Inactive ✅";
   const mention = toTimestampMention(expiration);
   const relativeMention = toRelativeTimestampMention(expiration);
   return `Active until ${mention} (${relativeMention}) ⌛`;
@@ -131,14 +130,14 @@ function splitIntoEmbedPages(
   formattedDumpEntries: string[],
   maxCharsPerPage: number = MAX_DESCRIPTION_LENGTH,
 ): EmbedBuilder[] {
-  const embeds: EmbedBuilder[] = []
+  const embeds: EmbedBuilder[] = [];
   let description = "";
   for (const entry of formattedDumpEntries) {
     const { length } = entry;
     if (length > maxCharsPerPage) {
       log.warning( // TODO: not very helpful not knowing which dump lol.
         `a formatted cooldown dump has length ${length} > ` +
-        `${maxCharsPerPage}, cannot fit it into an embed page, skipped.`
+        `${maxCharsPerPage}, cannot fit it into an embed page, skipped.`,
       );
       continue;
     }
@@ -167,12 +166,12 @@ const listCooldowns = new CommandBuilder();
 const slashCommandDefinition = new SlashCommandBuilder()
   .setName("cooldowns")
   .setDescription(
-    "List current cooldowns associated with message creation events."
+    "List current cooldowns associated with message creation events.",
   )
   .addStringOption(input => input
     .setName("listener")
     .setDescription("ID of the listener (omit to list ALL cooldowns).")
-    .setAutocomplete(true)
+    .setAutocomplete(true),
   );
 addBroadcastOption(slashCommandDefinition);
 

--- a/src/controllers/dev/cooldowns/override-cooldown.command.ts
+++ b/src/controllers/dev/cooldowns/override-cooldown.command.ts
@@ -1,9 +1,4 @@
-import {
-  Events,
-  GuildMember,
-  Role,
-  SlashCommandBuilder
-} from "discord.js";
+import { Events, GuildMember, Role, SlashCommandBuilder } from "discord.js";
 
 import { BotClient } from "../../../bot/client";
 import {
@@ -19,13 +14,13 @@ import { listenerIdAutocomplete } from "./cooldowns.autocomplete";
 const overrideCooldown = new CommandBuilder();
 
 const slashCommandDefinition = new SlashCommandBuilder()
-  .setName(`override-listener-cooldown`)
-  .setDescription(`Set cooldown overrides for a message creation listener.`)
+  .setName("override-listener-cooldown")
+  .setDescription("Set cooldown overrides for a message creation listener.")
   .addStringOption(input => input
     .setName("listener")
     .setDescription("Listener ID.")
     .setRequired(true)
-    .setAutocomplete(true)
+    .setAutocomplete(true),
   )
   .addMentionableOption(input => input
     .setName("mentionable")
@@ -34,19 +29,19 @@ const slashCommandDefinition = new SlashCommandBuilder()
     // implementation of /cooldowns (which returns an unpaginated text
     // response) error out from exceeded message length limit.
     .setDescription("Member or role to set overrides for.")
-    .setRequired(true)
+    .setRequired(true),
   )
   .addNumberOption(input => input
     .setName("duration")
     .setDescription(
       "User-specific cooldown duration override " +
-      "(in seconds) (USER type cooldown only)."
+      "(in seconds) (USER type cooldown only).",
     )
-    .setMinValue(0)
+    .setMinValue(0),
   )
   .addBooleanOption(input => input
     .setName("bypass")
-    .setDescription("Allow this user to bypass cooldown duration.")
+    .setDescription("Allow this user to bypass cooldown duration."),
   );
 addBroadcastOption(slashCommandDefinition);
 
@@ -105,8 +100,7 @@ overrideCooldown.execute(async (interaction) => {
       });
       return;
     }
-    for (const member of members)
-      cooldown.setDuration(duration, member.id);
+    for (const member of members) {cooldown.setDuration(duration, member.id);}
     await interaction.reply({
       content:
         `Set **${listenerId}** cooldown duration override for ` +
@@ -119,8 +113,7 @@ overrideCooldown.execute(async (interaction) => {
   }
 
   if (bypass !== null) {
-    for (const member of members)
-      cooldown.setBypass(bypass, member.id);
+    for (const member of members) {cooldown.setBypass(bypass, member.id);}
     await interaction.reply({
       content:
         `${bypass ? "Enabled" : "Disabled"} **${listenerId}** bypass ` +

--- a/src/controllers/dev/cooldowns/set-cooldown.command.ts
+++ b/src/controllers/dev/cooldowns/set-cooldown.command.ts
@@ -18,13 +18,13 @@ import { listenerIdAutocomplete } from "./cooldowns.autocomplete";
 const setCooldown = new CommandBuilder();
 
 const slashCommandDefinition = new SlashCommandBuilder()
-  .setName(`set-listener-cooldown`)
+  .setName("set-listener-cooldown")
   .setDescription("Set the cooldown spec for the a message creation listener.")
   .addStringOption(input => input
     .setName("listener")
     .setDescription("Listener ID.")
     .setRequired(true)
-    .setAutocomplete(true)
+    .setAutocomplete(true),
   )
   .addStringOption(input => input
     .setName("type")
@@ -35,12 +35,12 @@ const slashCommandDefinition = new SlashCommandBuilder()
       { name: "Per-user", value: "user" },
       { name: "Per-channel", value: "channel" },
       { name: "Disabled", value: "disabled" },
-    )
+    ),
   )
   .addNumberOption(input => input
     .setName("seconds")
     .setDescription("Default duration of cooldown (in seconds).")
-    .setMinValue(0)
+    .setMinValue(0),
   );
 addBroadcastOption(slashCommandDefinition);
 

--- a/src/controllers/dev/ping.command.ts
+++ b/src/controllers/dev/ping.command.ts
@@ -1,22 +1,13 @@
+import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 
-import {
-  ChatInputCommandInteraction,
-  SlashCommandBuilder,
-} from "discord.js";
+import { CommandBuilder, CommandSpec } from "../../types/command.types";
 
-import {
-  CommandBuilder, CommandSpec
-} from "../../types/command.types";
-
-import getLogger from "../../logger";
 import { IClientWithIntentsAndRunners } from "../../types/client.abc";
 import {
   toRelativeTimestampMention,
   toTimestampMention,
 } from "../../utils/markdown.utils";
 import { addBroadcastOption } from "../../utils/options.utils";
-
-const log = getLogger(__filename);
 
 const slashCommandDefinition = new SlashCommandBuilder()
   .setName("ping")
@@ -35,8 +26,9 @@ async function respondWithDevDetails(
   // startup. Supposedly this is because the client has not sent its first
   // heartbeat yet.
   if (latency === -1) {
-    text += `\n* Latency: (still being calculated...)`
-  } else {
+    text += "\n* Latency: (still being calculated...)";
+  }
+  else {
     text += `\n* Latency: **${latency}** ms`;
     if (latency == 69) { // Easter egg.
       text += " (nice)";

--- a/src/controllers/dev/presence.command.ts
+++ b/src/controllers/dev/presence.command.ts
@@ -42,20 +42,20 @@ const slashCommandDefinition = new SlashCommandBuilder()
   .addStringOption(input => input
     .setName("activity_type")
     .setDescription("Activity type (determines the verb used).")
-    .addChoices(...activityChoices)
+    .addChoices(...activityChoices),
   )
   .addStringOption(input => input
     .setName("activity_name")
-    .setDescription("Text to follow the activity verb.")
+    .setDescription("Text to follow the activity verb."),
   )
   .addStringOption(input => input
     .setName("status")
     .setDescription("Status of the bot.")
-    .addChoices(...statusChoices)
+    .addChoices(...statusChoices),
   )
   .addBooleanOption(input => input
     .setName("clear_activity")
-    .setDescription("Clear current activity (ignores other activity options)")
+    .setDescription("Clear current activity (ignores other activity options)"),
   );
 
 async function updateBotPresence(
@@ -76,7 +76,8 @@ async function updateBotPresence(
   // Ignore the other activity options and just clear the activity.
   if (clearActivity) {
     client.user.setActivity();
-  } else {
+  }
+  else {
     // Activity requires a name. Type is optional. If the caller specifies a
     // type without a name, we can't make the API call, so it's an error.
     if (activityType && !activityName) {
@@ -98,7 +99,7 @@ async function updateBotPresence(
       });
       log.info(
         `${context}: set bot activity to ` +
-        `(${activityTypeValue}, ${activityName}).`
+        `(${activityTypeValue}, ${activityName}).`,
       );
     }
   }

--- a/src/controllers/moderation/profanity.listener.ts
+++ b/src/controllers/moderation/profanity.listener.ts
@@ -38,13 +38,13 @@ function checkAndLogProfanityMatches(message: Message): boolean {
       englishDataset.getPayloadWithPhraseMetadata(match);
     if (!phraseMetadata) continue;
     entries.push(
-      `${phraseMetadata.originalWord}@[${startIndex}:${endIndex}]`
+      `${phraseMetadata.originalWord}@[${startIndex}:${endIndex}]`,
     );
   }
 
   const context = formatContext(message);
   log.info(
-    `${context}: detected profanity in ${message.url}: ${entries.join(", ")}`
+    `${context}: detected profanity in ${message.url}: ${entries.join(", ")}`,
   );
   return true;
 }

--- a/src/controllers/users/coffee/crazy.listener.ts
+++ b/src/controllers/users/coffee/crazy.listener.ts
@@ -19,20 +19,27 @@ async function replyWithNextLineInCrazyCopypasta(message: Message) {
   const withoutEndPunct = chars.replace(/[.!?~-]$/, "");
 
   let response: string;
-  if (chars.endsWith("crazy?"))
+  if (chars.endsWith("crazy?")) {
     response = "I was crazy once.";
-  else if (/.*crazy[.!~-]*$/i.exec(message.content))
+  }
+  else if (/.*crazy[.!~-]*$/i.exec(message.content)) {
     response = "Crazy?";
-  else if (withoutEndPunct === "i was crazy once")
+  }
+  else if (withoutEndPunct === "i was crazy once") {
     response = "They locked me in a room";
-  else if (withoutEndPunct === "they locked me in a room")
+  }
+  else if (withoutEndPunct === "they locked me in a room") {
     response = "A rubber room";
-  else if (withoutEndPunct === "a rubber room")
+  }
+  else if (withoutEndPunct === "a rubber room") {
     response = "A rubber room with rats";
-  else if (withoutEndPunct === "a rubber room with rats")
+  }
+  else if (withoutEndPunct === "a rubber room with rats") {
     response = "And rats make me crazy";
-  else
-    return
+  }
+  else {
+    return;
+  }
 
   await replySilently(message, response);
   log.debug(`${formatContext(message)}: replied with '${response}'.`);

--- a/src/controllers/users/coffee/lofi.listener.ts
+++ b/src/controllers/users/coffee/lofi.listener.ts
@@ -18,11 +18,10 @@ async function reactWithLOFI(message: Message) {
   await message.react("🇫");
   await message.react("🇮");
   log.debug(`${formatContext(message)}: reacted with LOFI.`);
-};
+}
 
 async function isLukeOrCoffeeReplyingToEachOther(message: Message) {
-  if (!message.reference)
-    return false;
+  if (!message.reference) return false;
 
   const referenceId = message.reference.messageId!;
   const referencedMessage = await message.channel.messages.fetch(referenceId);

--- a/src/controllers/users/coffee/uwu.listener.ts
+++ b/src/controllers/users/coffee/uwu.listener.ts
@@ -7,7 +7,10 @@ import {
   useCooldown,
 } from "../../../middleware/cooldown.middleware";
 import { contentMatching } from "../../../middleware/filters.middleware";
-import { ListenerSpec, MessageListenerBuilder } from "../../../types/listener.types";
+import {
+  ListenerSpec,
+  MessageListenerBuilder,
+} from "../../../types/listener.types";
 import { formatContext } from "../../../utils/logging.utils";
 
 const log = getLogger(__filename);
@@ -16,7 +19,7 @@ async function reactWithVomit(message: Message) {
   await message.react("🤢");
   await message.react("🤮");
   log.debug(`${formatContext(message)}: reacted to uwu.`);
-};
+}
 
 const cooldown = new CooldownManager({
   type: "global",

--- a/src/controllers/users/cxtie/chat-revive.listener.ts
+++ b/src/controllers/users/cxtie/chat-revive.listener.ts
@@ -18,7 +18,7 @@ const log = getLogger(__filename);
 async function replyWithNo(message: Message) {
   await replySilently(message, "no");
   log.debug(`${formatContext(message)}: denied chat revival.`);
-};
+}
 
 function containsChatReviveWithPossibleMarkdown(message: Message): boolean {
   const chatReviveWithPossibleMD = /^(?:#+ )?chat revive[.!?~]*$/i;

--- a/src/controllers/users/cxtie/no-x-no.listener.ts
+++ b/src/controllers/users/cxtie/no-x-no.listener.ts
@@ -1,4 +1,7 @@
-import { CooldownManager, useCooldown } from "../../../middleware/cooldown.middleware";
+import {
+  CooldownManager,
+  useCooldown,
+} from "../../../middleware/cooldown.middleware";
 import {
   channelPollutionAllowed,
   contentMatching,

--- a/src/controllers/users/cxtie/set-react-chance.command.ts
+++ b/src/controllers/users/cxtie/set-react-chance.command.ts
@@ -24,8 +24,8 @@ setReactChance.define(new SlashCommandBuilder()
     .setRequired(true)
     .setMinValue(0)
     .setMaxValue(1)
-    .setDescription("Probability expressed as a decimal.")
-  )
+    .setDescription("Probability expressed as a decimal."),
+  ),
 );
 
 setReactChance.check(checkPrivilege(RoleLevel.BABY_MOD));
@@ -40,7 +40,7 @@ setReactChance.execute(async (interaction) => {
 
   await interaction.reply(
     "Updated anti-Cxtie react chance from " +
-    `${oldProbability} to ${newProbability}.`
+    `${oldProbability} to ${newProbability}.`,
   );
 });
 

--- a/src/controllers/users/cxtie/sniffs.listener.ts
+++ b/src/controllers/users/cxtie/sniffs.listener.ts
@@ -49,7 +49,8 @@ onSniffs.execute(async (message) => {
   if (wouldSniffBack) {
     await replySilently(message, responseToEcho);
     log.info(`${context}: echoed '${responseToEcho}'.`);
-  } else {
+  }
+  else {
     await replySilently(message, "daily cxtie appreciation");
     log.info(`${context}: appreciated cxtie.`);
   }

--- a/src/controllers/users/cxtie/tempy-wempy.listener.ts
+++ b/src/controllers/users/cxtie/tempy-wempy.listener.ts
@@ -27,13 +27,14 @@ onTempyWempy.execute(async (message) => {
     await message.react("🇴");
     await message.react("🇵");
     reacted = true;
-  } else {
+  }
+  else {
     await replySilently(message, "Stop calling me that.");
     reacted = false;
   }
   log.debug(
     `${formatContext(message)}: protested being called "tempy wempy" ` +
-    `(${reacted ? "reacted" : "replied"}).`
+    `(${reacted ? "reacted" : "replied"}).`,
   );
 });
 

--- a/src/controllers/users/deez/deez.listener.ts
+++ b/src/controllers/users/deez/deez.listener.ts
@@ -1,12 +1,18 @@
 import { Events, Message } from "discord.js";
 
 import getLogger from "../../../logger";
-import { CooldownManager, useCooldown } from "../../../middleware/cooldown.middleware";
+import {
+  CooldownManager,
+  useCooldown,
+} from "../../../middleware/cooldown.middleware";
 import {
   channelPollutionAllowed,
   contentMatching,
 } from "../../../middleware/filters.middleware";
-import { ListenerSpec, MessageListenerBuilder } from "../../../types/listener.types";
+import {
+  ListenerSpec,
+  MessageListenerBuilder,
+} from "../../../types/listener.types";
 import { replySilently } from "../../../utils/interaction.utils";
 import { formatContext } from "../../../utils/logging.utils";
 
@@ -15,7 +21,7 @@ const log = getLogger(__filename);
 async function execute(message: Message) {
   await replySilently(message, "deez");
   log.debug(`${formatContext(message)}: replied with deez.`);
-};
+}
 
 const cooldown = new CooldownManager({ type: "global", seconds: 600 });
 

--- a/src/controllers/users/luke/random-meow.listener.ts
+++ b/src/controllers/users/luke/random-meow.listener.ts
@@ -1,4 +1,3 @@
-
 import config from "../../../config";
 import getLogger from "../../../logger";
 import {

--- a/src/controllers/users/luke/set-meow-chance.command.ts
+++ b/src/controllers/users/luke/set-meow-chance.command.ts
@@ -24,8 +24,8 @@ setMeowChance.define(new SlashCommandBuilder()
       .setRequired(true)
       .setMinValue(0)
       .setMaxValue(1)
-      .setDescription("Probability expressed as a decimal.")
-  )
+      .setDescription("Probability expressed as a decimal."),
+  ),
 );
 
 setMeowChance.check(checkPrivilege(RoleLevel.BABY_MOD));
@@ -39,7 +39,7 @@ setMeowChance.execute(async (interaction) => {
   log.info(`${context}: set Luke meow chance to ${newProbability}.`);
 
   interaction.reply(
-    `Updated Luke meow chance from ${oldProbability} to ${newProbability}.`
+    `Updated Luke meow chance from ${oldProbability} to ${newProbability}.`,
   );
 });
 

--- a/src/controllers/users/taco/mudae-appreciation.listener.ts
+++ b/src/controllers/users/taco/mudae-appreciation.listener.ts
@@ -11,10 +11,10 @@ const log = getLogger(__filename);
 
 /** Mapping from name on character card to string to use when appreciating. */
 const NAMES_TO_APPRECIATE = new Map<string, string>([
-  ["Atsuko Kagari", "akko"],  // Taco.
-  ["Saber", "saber"],         // Luke.
+  ["Atsuko Kagari", "akko"], // Taco.
+  ["Saber", "saber"], // Luke.
   ["Hua Cheng", "hua cheng"], // Coffee.
-  ["Nana Osaki", "nana"],     // Coffee.
+  ["Nana Osaki", "nana"], // Coffee.
 ]);
 
 const onAppreciatedChar = new MessageListenerBuilder()

--- a/src/controllers/users/wav/pookie.listener.ts
+++ b/src/controllers/users/wav/pookie.listener.ts
@@ -7,6 +7,7 @@ import {
 import { contentMatching } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
+import { formatContext } from "../../../utils/logging.utils";
 
 const log = getLogger(__filename);
 
@@ -15,6 +16,7 @@ const onPookie = new MessageListenerBuilder().setId("pookie");
 onPookie.filter(contentMatching(/^pookie$/i));
 onPookie.execute(async (message) => {
   await message.react(GUILD_EMOJIS.NEKO_UWU);
+  log.debug(`${formatContext(message)}: reacted to pookie.`);
 });
 
 const cooldown = new CooldownManager({

--- a/src/controllers/users/wav/tacocat-appreciation.listener.ts
+++ b/src/controllers/users/wav/tacocat-appreciation.listener.ts
@@ -1,7 +1,7 @@
 import config from "../../../config";
 import {
   contentMatching,
-  messageFrom
+  messageFrom,
 } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { replySilentlyWith } from "../../../utils/interaction.utils";

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -36,7 +36,7 @@ function getLogFormat({ colorized }: { colorized: boolean }) {
     formats.push(winston.format.colorize());
   }
   formats.push(winston.format.printf(info =>
-    `[${info.timestamp}] ${info.moduleName} ${info.level}: ${info.message}`
+    `[${info.timestamp}] ${info.moduleName} ${info.level}: ${info.message}`,
   ));
   return winston.format.combine(...formats);
 }
@@ -54,7 +54,8 @@ if (config.NODE_ENV === "development") {
     filename: VOLATILE_LOG_PATH,
     format: getLogFormat({ colorized: false }),
   }));
-} else if (config.NODE_ENV === "production") {
+}
+else if (config.NODE_ENV === "production") {
   transports.push(new DailyRotateFile({
     dirname: LOGS_DIR_PATH,
     filename: "production-%DATE%.log",

--- a/src/middleware/cooldown.middleware.ts
+++ b/src/middleware/cooldown.middleware.ts
@@ -1,8 +1,4 @@
-import {
-  Awaitable,
-  Events,
-  Message,
-} from "discord.js";
+import { Awaitable, Events, Message } from "discord.js";
 import lodash from "lodash";
 
 import getLogger from "../logger";
@@ -236,7 +232,8 @@ export abstract class PerIDCooldownManager<
   public override setDuration(seconds: number, discordId?: string): void {
     if (discordId === undefined) {
       this.spec.defaultSeconds = seconds;
-    } else {
+    }
+    else {
       this.overrides.set(discordId, seconds);
     }
   }
@@ -247,9 +244,9 @@ export abstract class PerIDCooldownManager<
   }
 
   public override dump(): DumpType {
-    // @ts-ignore "{ ...} is assignable to the constraint of type 'DumpType',
-    // but 'DumpType' could be instantiated with a different subtype of
-    // constraint 'PerIDCooldownDump'. ts(2322)""
+    // @ts-expect-error "{ ...} is assignable to the constraint of type
+    // 'DumpType', but 'DumpType' could be instantiated with a different subtype
+    // of constraint 'PerIDCooldownDump'. ts(2322)""
     return {
       type: this.type,
       expirations: this.expirations,
@@ -437,7 +434,8 @@ export function useCooldown(
   let manager: CooldownManager;
   if (value instanceof CooldownManager) {
     manager = value;
-  } else {
+  }
+  else {
     manager = new CooldownManager();
     manager.set(value);
   }

--- a/src/middleware/filters.middleware.ts
+++ b/src/middleware/filters.middleware.ts
@@ -33,13 +33,13 @@ export function isPollutionImmuneChannel(
   channel: GuildTextBasedChannel,
 ): boolean {
   // Might be best to not annoy the kiddos too much.
-  if (channel.name.indexOf("general") !== -1)
-    return true;
+  if (channel.name.indexOf("general") !== -1) return true;
 
   // Don't pollute important channels.
   const importantSubstrings = ["introductions", "announcements", "welcome"];
-  if (importantSubstrings.some(s => channel.name.indexOf(s) !== -1))
+  if (importantSubstrings.some(s => channel.name.indexOf(s) !== -1)) {
     return true;
+  }
 
   // TODO: Maybe also somehow ignore "serious" channels (such as forum posts
   // tagged with Mental Health).
@@ -72,7 +72,7 @@ export function channelPollutionAllowedOrBypass(
   ...bypasserUids: string[]
 ): MessageFilterFunction {
   return function (message) {
-    const channel = message.channel as GuildTextBasedChannel
+    const channel = message.channel as GuildTextBasedChannel;
     const pollutionAllowed = !isPollutionImmuneChannel(channel);
     const canBypass = bypasserUids.includes(message.author.id);
     return pollutionAllowed || canBypass;
@@ -93,15 +93,15 @@ export function randomly(successChance:
     ? successChance
     : () => successChance;
 
-  return async function (_) {
+  return async function () {
     const chance = await getSuccessChance();
     if (chance < 0 || chance > 1) {
       throw new Error(
-        `success chance must be in range [0, 1] but received ${successChance}`
+        `success chance must be in range [0, 1] but received ${successChance}`,
       );
     }
     return Math.random() < chance;
-  }
+  };
 }
 
 /**
@@ -112,7 +112,7 @@ export function containsCustomEmoji(emojiId: string): MessageFilterFunction {
   return function (message) {
     const emojis = parseCustomEmojis(message.content);
     return emojis.some(e => e.id === emojiId);
-  }
+  };
 }
 
 /**
@@ -122,5 +122,5 @@ export function containsCustomEmoji(emojiId: string): MessageFilterFunction {
 export function containsEmoji(unicodeEmoji: string): MessageFilterFunction {
   return function (message) {
     return message.content.includes(unicodeEmoji);
-  }
+  };
 }

--- a/src/middleware/privilege.middleware.ts
+++ b/src/middleware/privilege.middleware.ts
@@ -33,7 +33,7 @@ export enum RoleLevel {
    * Is one of the bot developers (aka "bot master").
    */
   DEV,
-};
+}
 
 export const LEVEL_TO_RID: Record<
   Exclude<RoleLevel, RoleLevel.NONE>,
@@ -51,8 +51,9 @@ export function checkPrivilege(commandLevel: RoleLevel): CommandCheck {
     for (const [level, roleId] of iterateEnum(LEVEL_TO_RID)) {
       // As long as the level required by the command is less than any of the
       // levels for which the caller has a role, then they pass.
-      if (commandLevel <= level && member.roles.cache.has(roleId))
+      if (commandLevel <= level && member.roles.cache.has(roleId)) {
         return true;
+      }
     }
     return false;
   }

--- a/src/services/cxtie.service.ts
+++ b/src/services/cxtie.service.ts
@@ -8,7 +8,7 @@ const log = getLogger(__filename);
 
 // NOTE: These emojis are from outside yung kai world so they are not part of
 // our custom emojis mapping.
-export const SUP_EMOJI_ID = "1171056612761403413"
+export const SUP_EMOJI_ID = "1171056612761403413";
 export const SLAY_EMOJI_ID = "1176908139896000623";
 
 export class CxtieService {
@@ -29,7 +29,7 @@ export class CxtieService {
       return isCringe;
     });
     return containsCringe;
-  }
+  };
 }
 
 export default new CxtieService();

--- a/src/services/luke.service.ts
+++ b/src/services/luke.service.ts
@@ -12,11 +12,11 @@ export class LukeService {
 
   public getMeowChance = (): number => {
     return this.meowChance;
-  }
+  };
 
   public setMeowChance = (probability: number): void => {
     this.meowChance = probability;
-  }
+  };
 
   public processDadJoke = async (message: Message): Promise<boolean> => {
     // Use .member instead of .author so .displayName works as expected.
@@ -25,7 +25,7 @@ export class LukeService {
     const TRIGGER_REGEXP = /^i(?:['’]| a)?m(\s+not)?\s+(.+)/i;
     const matches = TRIGGER_REGEXP.exec(message.content);
     if (matches === null) return false;
-    const [_, notPresent, captured] = matches;
+    const [, notPresent, captured] = matches;
 
     let response: string;
 
@@ -36,20 +36,20 @@ export class LukeService {
     }
 
     // Affirmative version of the joke.
+    else if (captured.match(/^(back|awake|up|here)[.~!?-]*$/i)) {
+      response = `Welcome back, ${author.displayName}!`;
+    }
     else {
-      if (captured.match(/^(back|awake|up|here)[.~!?-]*$/i))
-        response = `Welcome back, ${author.displayName}!`;
-      else
-        response = `Hi ${captured}, I'm ${message.client.user.displayName}!`;
+      response = `Hi ${captured}, I'm ${message.client.user.displayName}!`;
     }
 
     await replySilently(message, response);
     log.debug(
       `${formatContext(message)}: replied with Dad joke ` +
-      `(${notPresent ? "negative" : "affirmative"} version).`
+      `(${notPresent ? "negative" : "affirmative"} version).`,
     );
     return true;
-  }
-};
+  };
+}
 
 export default new LukeService();

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -22,7 +22,7 @@ function getCurrentBranchName(): string | null {
     const stderr = process.stderr?.toString().trim();
     log.warning(
       `\`${command}\` failed with exit code ${process.status}` +
-      (stderr ? `: ${stderr}` : "")
+      (stderr ? `: ${stderr}` : ""),
     );
     return null;
   }
@@ -80,10 +80,8 @@ export abstract class IClientWithIntentsAndRunners extends Client {
     const ignoreSelf: ListenerFilter<Events.MessageCreate> = {
       predicate: message => !this.isMessageFromSelf(message),
     };
-    if (!runner.spec.filters)
-      runner.spec.filters = [ignoreSelf]
-    else
-      runner.spec.filters.push(ignoreSelf);
+    if (!runner.spec.filters) runner.spec.filters = [ignoreSelf];
+    else runner.spec.filters.push(ignoreSelf);
   }
 
   public registerListeners(): void {
@@ -94,7 +92,8 @@ export abstract class IClientWithIntentsAndRunners extends Client {
 
       if (runner.spec.once) {
         this.once(runner.spec.type, runner.callbackToRegister);
-      } else {
+      }
+      else {
         this.on(runner.spec.type, runner.callbackToRegister);
       }
       log.debug(`registered event listener '${id}'.`);

--- a/src/types/command.types.ts
+++ b/src/types/command.types.ts
@@ -150,7 +150,8 @@ export class CommandBuilder {
   ): this {
     if (isAnySlashCommandBuilder(definition)) {
       this.definition = definition.toJSON();
-    } else {
+    }
+    else {
       this.definition = definition;
     }
     return this;
@@ -163,7 +164,8 @@ export class CommandBuilder {
     // a lone predicate or as a complete CommandCheck object.
     if (typeof check === "function") {
       this.checks.push({ predicate: check });
-    } else {
+    }
+    else {
       this.checks.push(check);
     }
     return this;

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -1,9 +1,9 @@
 declare global {
   type EnvironmentVariables = {
 
-    //////////////////////////
+    // ////////////////////////
     //     SDLC Related     //
-    //////////////////////////
+    // ////////////////////////
 
     /**
      * Environment corresponding to the current software development lifecycle
@@ -19,9 +19,9 @@ declare global {
      * */
     LOGGER_LEVEL?: "error" | "warning" | "info" | "debug";
 
-    /////////////////////////
+    // ///////////////////////
     //     Bot Related     //
-    /////////////////////////
+    // ///////////////////////
 
     /**
      * Discord bot token generated on the Discord Developer Dashboard.
@@ -37,9 +37,9 @@ declare global {
      */
     YUNG_KAI_WORLD_GID: string;
 
-    //////////////////////////////
+    // ////////////////////////////
     //     Discord Role IDs     //
-    //////////////////////////////
+    // ////////////////////////////
 
     /**
      * Role ID for bot developers.
@@ -58,9 +58,9 @@ declare global {
      */
     BABY_MOD_RID: string;
 
-    //////////////////////////////
+    // ////////////////////////////
     //     Discord User IDs     //
-    //////////////////////////////
+    // ////////////////////////////
 
     LUKE_UID: string;
     KLEE_UID: string;
@@ -73,9 +73,9 @@ declare global {
     KAI_UID: string;
     NI_UID: string;
 
-    /////////////////////////////
+    // ///////////////////////////
     //     Discord Bot IDs     //
-    /////////////////////////////
+    // ///////////////////////////
 
     MUDAE_UID: string;
   };

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -145,7 +145,8 @@ export class ListenerBuilder<Type extends keyof ClientEvents> {
     // a lone predicate or as a complete `ListenerFilter` object.
     if (typeof filter === "function") {
       this.filters.push({ predicate: filter });
-    } else {
+    }
+    else {
       this.filters.push(filter);
     }
     return this;
@@ -206,11 +207,9 @@ export class MessageListenerBuilder
    * that wants to query/update the cooldown through the bot client at runtime.
    */
   public cooldown(arg: CooldownManager | CooldownSpec): this {
-    let manager: CooldownManager
-    if (arg instanceof CooldownManager)
-      manager = arg;
-    else
-      manager = new CooldownManager(arg);
+    let manager: CooldownManager;
+    if (arg instanceof CooldownManager) manager = arg;
+    else manager = new CooldownManager(arg);
     this.filter(useCooldown(manager));
     this.cooldownManager = manager;
     return this;

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -12,7 +12,7 @@ export function parseCustomEmojis(content: string): Required<CustomEmoji>[] {
   const matches = content.matchAll(CUSTOM_EMOJI_REGEXP);
   const emojis: Required<CustomEmoji>[] = [];
   for (const match of matches) {
-    const [_, a, name, id] = match;
+    const [, a, name, id] = match;
     const animated = !!a;
     emojis.push({ name, id, animated });
   }

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -39,5 +39,5 @@ export function reactWith(emoji: EmojiResolvable)
   return async (message) => {
     await message.react(emoji);
     log.debug(`${formatContext(message)}: reacted with ${emoji}.`);
-  }
+  };
 }

--- a/src/utils/iteration.utils.ts
+++ b/src/utils/iteration.utils.ts
@@ -16,7 +16,7 @@ import { GuildMember, Role } from "discord.js";
  * NOTE: This doesn't seem to work as expected! When iterating over a numeric
  * enum, the numbers seem to be included as part of the keys.
  */
-export function iterateEnum<T extends {}>(enumerable: T)
+export function iterateEnum<T extends object>(enumerable: T)
   : [keyof T, T[keyof T]][] {
   return Object.entries(enumerable) as [keyof T, T[keyof T]][];
 }

--- a/src/utils/options.utils.ts
+++ b/src/utils/options.utils.ts
@@ -3,13 +3,13 @@ import { AnySlashCommandBuilder } from "../types/command.types";
 export function addBroadcastOption(builder: AnySlashCommandBuilder): void {
   builder.addBooleanOption(input => input
     .setName("broadcast")
-    .setDescription("Whether to respond publicly instead of ephemerally.")
+    .setDescription("Whether to respond publicly instead of ephemerally."),
   );
 }
 
 export function addEphemeralOption(builder: AnySlashCommandBuilder): void {
   builder.addBooleanOption(input => input
     .setName("ephemeral")
-    .setDescription("Whether to make the response ephemeral instead of public.")
+    .setDescription("Whether to make response ephemeral instead of public."),
   );
 }

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -3,11 +3,7 @@ import {
   toRelativeTimestampMention,
   toTimestampMention,
 } from "../../../src/utils/markdown.utils";
-import {
-  MockInteraction,
-  TestClient,
-  addMockGetter,
-} from "../../test-utils";
+import { MockInteraction, TestClient, addMockGetter } from "../../test-utils";
 
 describe("/ping command", () => {
   let mock: MockInteraction;

--- a/tests/controllers/dev/presence.command.test.ts
+++ b/tests/controllers/dev/presence.command.test.ts
@@ -33,7 +33,7 @@ it("should clear the activity as long as the flag is set", async () => {
   mock
     .mockCallerRoles(config.BOT_DEV_RID)
     .mockOption("Boolean", "clear_activity", true)
-    .mockOption("String", "activity_name", "unit testing!")
+    .mockOption("String", "activity_name", "unit testing!");
   await mock.simulateCommand();
   expect(mock.interaction.client.user.setActivity).toHaveBeenLastCalledWith();
   mock.expectReplied();

--- a/tests/controllers/users/cxtie/rizz.listener.test.ts
+++ b/tests/controllers/users/cxtie/rizz.listener.test.ts
@@ -21,7 +21,7 @@ describe("rizz listener", () => {
   it("should react if content is 'tucks hair'", async () => {
     const mock = new MockMessage(onRizzSpec)
       .mockAuthorId(config.CXTIE_UID!)
-      .mockContent(`*tucks hair*`);
+      .mockContent("*tucks hair*");
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_GUN);
   });

--- a/tests/controllers/users/cxtie/sniffs.listener.test.ts
+++ b/tests/controllers/users/cxtie/sniffs.listener.test.ts
@@ -1,12 +1,15 @@
 import config from "../../../../src/config";
 import onSniffsSpec from "../../../../src/controllers/users/cxtie/sniffs.listener";
-import { GUILD_EMOJIS, toEscapedEmoji } from "../../../../src/utils/emojis.utils";
+import {
+  GUILD_EMOJIS,
+  toEscapedEmoji,
+} from "../../../../src/utils/emojis.utils";
 import { MockMessage } from "../../../test-utils";
 
 describe("sniffs listener", () => {
   afterEach(() => {
     jest.spyOn(global.Math, "random").mockRestore();
-  })
+  });
 
   it("should only listen to Cxtie", async () => {
     const mock = new MockMessage(onSniffsSpec).mockContent("i'm not cxtie");

--- a/tests/controllers/users/klee/dab.listener.test.ts
+++ b/tests/controllers/users/klee/dab.listener.test.ts
@@ -6,7 +6,7 @@ describe("dab listener", () => {
   let mock: MockMessage;
   beforeEach(() => {
     mock = new MockMessage(onDabSpec);
-  })
+  });
 
   it("shouldn't respond if the content isn't dab", async () => {
     mock.mockContent("lorem ipsum").mockAuthorBot(false);

--- a/tests/controllers/users/luke/random-meow.listener.test.ts
+++ b/tests/controllers/users/luke/random-meow.listener.test.ts
@@ -12,7 +12,7 @@ describe("random-meow listener", () => {
   beforeEach(() => {
     mock = new MockMessage(randomMeowerSpec)
       .mockAuthor({ uid: config.LUKE_UID });
-  })
+  });
 
   afterEach(() => {
     jest.spyOn(global.Math, "random").mockRestore();

--- a/tests/middleware/cooldown.middleware.test.ts
+++ b/tests/middleware/cooldown.middleware.test.ts
@@ -5,7 +5,10 @@ import {
   CooldownSpec,
   DisabledCooldownDump,
 } from "../../src/middleware/cooldown.middleware";
-import { getAllPermute2, unorderedEquals } from "../../src/utils/iteration.utils";
+import {
+  getAllPermute2,
+  unorderedEquals,
+} from "../../src/utils/iteration.utils";
 import { expectMatchingSchema } from "../test-utils";
 import {
   channelCooldownDumpSchema,

--- a/tests/services/cxtie.service.test.ts
+++ b/tests/services/cxtie.service.test.ts
@@ -1,6 +1,10 @@
 import { Message } from "discord.js";
 import { DeepMockProxy, mockDeep } from "jest-mock-extended";
-import { CxtieService, SLAY_EMOJI_ID, SUP_EMOJI_ID } from "../../src/services/cxtie.service";
+import {
+  CxtieService,
+  SLAY_EMOJI_ID,
+  SUP_EMOJI_ID,
+} from "../../src/services/cxtie.service";
 import { CustomEmoji, toEscapedEmoji } from "../../src/utils/emojis.utils";
 
 let cxtieService: CxtieService;

--- a/tests/services/luke.service.test.ts
+++ b/tests/services/luke.service.test.ts
@@ -7,7 +7,7 @@ import { addMockGetter } from "../test-utils";
 let lukeService: LukeService;
 beforeEach(() => {
   lukeService = new LukeService();
-})
+});
 
 describe("meow chance", () => {
   it("should start with the initial meow chance", () => {
@@ -17,7 +17,7 @@ describe("meow chance", () => {
 
   it("should reflect the updated meow chance", () => {
     lukeService.setMeowChance(0.42);
-    const newChance = lukeService.getMeowChance()
+    const newChance = lukeService.getMeowChance();
     expect(newChance).toBeCloseTo(0.42);
   });
 });
@@ -38,7 +38,7 @@ describe("dad joke handler", () => {
     content: string,
   ): void {
     expect(mockMessage.reply).toHaveBeenCalledWith(
-      expect.objectContaining({ content })
+      expect.objectContaining({ content }),
     );
   }
 

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -13,11 +13,7 @@ import {
   MessageReference,
   MessageReplyOptions,
 } from "discord.js";
-import {
-  DeepMockProxy,
-  Matcher,
-  mockDeep,
-} from "jest-mock-extended";
+import { DeepMockProxy, Matcher, mockDeep } from "jest-mock-extended";
 import { z } from "zod";
 import { fromZodError } from "zod-validation-error";
 
@@ -144,12 +140,12 @@ export class MockInteraction {
   }
 }
 
-export function addMockGetter<ObjectType extends {}, ValueType>(
+export function addMockGetter<ObjectType extends object, ValueType>(
   obj: ObjectType,
   key: keyof ObjectType,
   value: ValueType,
 ): void;
-export function addMockGetter<ObjectType extends {}, ValueType>(
+export function addMockGetter<ObjectType extends object, ValueType>(
   obj: ObjectType,
   key: keyof ObjectType,
   getter: () => ValueType,
@@ -159,16 +155,19 @@ export function addMockGetter<ObjectType extends {}, ValueType>(
  * not supporting mocking getters yet. This can also be used to overwrite
  * read-only properties.
  */
-export function addMockGetter<ObjectType extends {}, ValueType>(
+export function addMockGetter<ObjectType extends object, ValueType>(
   obj: ObjectType,
   key: keyof ObjectType,
   getter: ValueType | (() => ValueType),
 ): jest.Mock<ValueType, [], any> {
   const mockGetter = jest.fn<ValueType, []>();
-  if (getter instanceof Function)
+  if (getter instanceof Function) {
     mockGetter.mockImplementation(getter);
-  else
+  }
+  else {
     mockGetter.mockReturnValue(getter);
+  }
+
   Object.defineProperty(obj, key, {
     get: mockGetter,
     configurable: true, // Allow redefining existing properties.
@@ -269,12 +268,15 @@ export class MockMessage {
    * Mock the message's author attached to the underlying message object.
    */
   public mockAuthor(options: MockAuthorOptions): this {
-    if (options.uid !== undefined)
+    if (options.uid !== undefined) {
       this.message.author.id = options.uid;
-    if (options.displayName !== undefined)
+    }
+    if (options.displayName !== undefined) {
       addMockGetter(this.message.author, "displayName", options.displayName);
-    if (options.bot !== undefined)
+    }
+    if (options.bot !== undefined) {
       this.message.author.bot = options.bot;
+    }
     return this;
   }
 
@@ -290,7 +292,7 @@ export class MockMessage {
       messageId: "MOCK-MESSAGE-ID",
     };
     this.message.reference = reference;
-    // @ts-ignore fetch literally resolves Message. For SOME reason,
+    // @ts-expect-error fetch literally resolves Message. For SOME reason,
     // mockImplementation wants the callback to resolve Collection<string,
     // Message>.
     this.message.channel.messages.fetch.mockImplementation(async (id) => {
@@ -377,7 +379,8 @@ export class MockMessage {
     let options: Partial<MessageReplyOptions>;
     if (typeof arg === "string") {
       options = { content: arg };
-    } else {
+    }
+    else {
       options = arg;
     }
     this.expectRepliedWith({

--- a/tests/utils/emojis.utils.test.ts
+++ b/tests/utils/emojis.utils.test.ts
@@ -1,4 +1,8 @@
-import { CustomEmoji, parseCustomEmojis, toEscapedEmoji } from "../../src/utils/emojis.utils";
+import {
+  CustomEmoji,
+  parseCustomEmojis,
+  toEscapedEmoji,
+} from "../../src/utils/emojis.utils";
 
 describe("parsing custom emojis", () => {
   it("should return all custom emojis in string", () => {

--- a/tests/utils/interaction.utils.test.ts
+++ b/tests/utils/interaction.utils.test.ts
@@ -1,7 +1,10 @@
 jest.mock("../../src/utils/logging.utils");
 
 import { Message, MessageFlags, MessageReplyOptions } from "discord.js";
-import { replySilently, replySilentlyWith } from "../../src/utils/interaction.utils";
+import {
+  replySilently,
+  replySilentlyWith,
+} from "../../src/utils/interaction.utils";
 
 const mockMessage = {
   reply: jest.fn(),


### PR DESCRIPTION
Closes #38.

* Set up initial ESLint configuration, using a combination of:
  * The settings bootstrapped from `npx eslint --init`.
  * Other settings from the [discord.js Guide on linting](https://discordjs.guide/preparations/setting-up-a-linter.html#setting-up-eslint-rules) (though I decided to reject/modify many of them).
  * Some `@typescript/eslint` overrides.
* Applied linting on all source files.
* Added new `npm run lint` and `npm run lint:fix` scripts.
* Added linting to the PR workflow. Code must now pass both the tests and linter to be allowed to merge.