### PR TITLE
Add support for monkey patching controllers

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -4,7 +4,7 @@ import { ClientEvents, Collection, REST, Routes } from "discord.js";
 
 import config from "../config";
 import getLogger from "../logger";
-import { IClientWithIntentsAndRunners } from "../types/client.abc";
+import { ClientWithIntentsAndRunnersABC } from "../types/client.abc";
 import {
   DuplicateListenerIDError,
   ListenerSpec,
@@ -27,7 +27,7 @@ const CONTROLLERS_DIR_PATH = path.join(__dirname, "..", "controllers");
  */
 const SPECIAL_LISTENERS_DIR_PATH = path.join(__dirname, "listeners");
 
-export class BotClient extends IClientWithIntentsAndRunners {
+export class BotClient extends ClientWithIntentsAndRunnersABC {
   private commandLoader = new CommandLoader(CONTROLLERS_DIR_PATH);
   private listenerLoader = new ListenerLoader(
     CONTROLLERS_DIR_PATH,

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -107,6 +107,24 @@ export class BotClient extends IClientWithIntentsAndRunners {
     if (!type) return asSpecs;
     return asSpecs.filter(spec => spec.type === type);
   }
+
+  public override clearDefinitions(): void {
+    // Clear the command mapping. Unlike for listeners, there's no "undoing
+    // registration" since commands and synced to Discord's backend. Instead,
+    // our command runner should intelligently handle commands that may be valid
+    // from Discord's POV but not from our runner's POV>
+    const numCommands = this.commandRunners.size;
+    this.commandRunners.clear();
+    log.warning(`removed ${numCommands} commands from client mapping.`);
+
+    // Undo callback registration before clearing the mapping.
+    for (const runner of this.listenerRunners.values()) {
+      this.removeListener(runner.spec.type, runner.callbackToRegister);
+    }
+    const numListeners = this.listenerRunners.size;
+    this.listenerRunners.clear();
+    log.warning(`removed ${numListeners} listeners from client mapping.`);
+  }
 }
 
 /**

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -34,9 +34,9 @@ export class BotClient extends IClientWithIntentsAndRunners {
     SPECIAL_LISTENERS_DIR_PATH,
   );
 
-  public override prepareRuntime(): boolean {
-    this.loadCommands();
-    this.loadListeners();
+  public override async prepareRuntime(): Promise<boolean> {
+    await this.loadCommands();
+    await this.loadListeners();
 
     try {
       this.registerListeners();
@@ -55,7 +55,7 @@ export class BotClient extends IClientWithIntentsAndRunners {
   }
 
   public override async deploySlashCommands(): Promise<void> {
-    this.loadCommands();
+    await this.loadCommands();
     const commandsJSON = this.commandRunners.map(r => r.getDeployJSON());
 
     const { BOT_TOKEN, APPLICATION_ID, YUNG_KAI_WORLD_GID } = config;
@@ -83,8 +83,8 @@ export class BotClient extends IClientWithIntentsAndRunners {
     }
   }
 
-  private loadCommands(): void {
-    const commandSpecs = this.commandLoader.load();
+  private async loadCommands(): Promise<void> {
+    const commandSpecs = await this.commandLoader.load();
     for (const spec of commandSpecs) {
       const commandName = spec.definition.name;
       this.commandRunners.set(commandName, new CommandRunner(spec));
@@ -92,8 +92,8 @@ export class BotClient extends IClientWithIntentsAndRunners {
     }
   }
 
-  private loadListeners(): void {
-    const allListenerSpecs = this.listenerLoader.load();
+  private async loadListeners(): Promise<void> {
+    const allListenerSpecs = await this.listenerLoader.load();
     for (const spec of allListenerSpecs) {
       const { id, type } = spec;
       this.listenerRunners.set(id, new ListenerRunner(spec));
@@ -108,7 +108,7 @@ export class BotClient extends IClientWithIntentsAndRunners {
     return asSpecs.filter(spec => spec.type === type);
   }
 
-  public override clearDefinitions(): void {
+  public override async clearDefinitions(): Promise<void> {
     // Clear the command mapping. Unlike for listeners, there's no "undoing
     // registration" since commands and synced to Discord's backend. Instead,
     // our command runner should intelligently handle commands that may be valid

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -28,18 +28,13 @@ const CONTROLLERS_DIR_PATH = path.join(__dirname, "..", "controllers");
 const SPECIAL_LISTENERS_DIR_PATH = path.join(__dirname, "listeners");
 
 export class BotClient extends IClientWithIntentsAndRunners {
-  public override readonly commandRunners
-    = new Collection<string, CommandRunner>();
-  public override readonly listenerRunners
-    = new Collection<string, ListenerRunner<any>>();
-
   private commandLoader = new CommandLoader(CONTROLLERS_DIR_PATH);
   private listenerLoader = new ListenerLoader(
     CONTROLLERS_DIR_PATH,
     SPECIAL_LISTENERS_DIR_PATH,
   );
 
-  public prepareRuntime(): boolean {
+  public override prepareRuntime(): boolean {
     this.loadCommands();
     this.loadListeners();
 
@@ -59,7 +54,7 @@ export class BotClient extends IClientWithIntentsAndRunners {
     }
   }
 
-  public async deploySlashCommands(): Promise<void> {
+  public override async deploySlashCommands(): Promise<void> {
     this.loadCommands();
     const commandsJSON = this.commandRunners.map(r => r.getDeployJSON());
 

--- a/src/bot/listeners/ready.listener.ts
+++ b/src/bot/listeners/ready.listener.ts
@@ -1,14 +1,14 @@
 import { Client, Events } from "discord.js";
 
 import getLogger from "../../logger";
-import { IClientWithIntentsAndRunners } from "../../types/client.abc";
+import { ClientWithIntentsAndRunnersABC } from "../../types/client.abc";
 import { ListenerBuilder, ListenerSpec } from "../../types/listener.types";
 
 const log = getLogger(__filename);
 
 async function handleReady(client: Client): Promise<void> {
   const now = new Date();
-  (client as IClientWithIntentsAndRunners).readySince = now;
+  (client as ClientWithIntentsAndRunnersABC).readySince = now;
   log.info(`bot ready! Logged in as ${client.user?.tag}.`);
 }
 

--- a/src/controllers/dev/ping.command.ts
+++ b/src/controllers/dev/ping.command.ts
@@ -2,7 +2,7 @@ import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
 
 import { CommandBuilder, CommandSpec } from "../../types/command.types";
 
-import { IClientWithIntentsAndRunners } from "../../types/client.abc";
+import { ClientWithIntentsAndRunnersABC } from "../../types/client.abc";
 import {
   toRelativeTimestampMention,
   toTimestampMention,
@@ -17,7 +17,7 @@ addBroadcastOption(slashCommandDefinition);
 async function respondWithDevDetails(
   interaction: ChatInputCommandInteraction,
 ): Promise<void> {
-  const client = interaction.client as IClientWithIntentsAndRunners;
+  const client = interaction.client as ClientWithIntentsAndRunnersABC;
 
   let text = "Hello there!";
 

--- a/src/controllers/dev/reload.command.ts
+++ b/src/controllers/dev/reload.command.ts
@@ -1,0 +1,107 @@
+import {
+  ChatInputCommandInteraction,
+  EmbedBuilder,
+  SlashCommandBuilder,
+} from "discord.js";
+
+import getLogger from "../../logger";
+import {
+  RoleLevel,
+  checkPrivilege,
+} from "../../middleware/privilege.middleware";
+import { IClientWithIntentsAndRunners } from "../../types/client.abc";
+import { CommandBuilder } from "../../types/command.types";
+import { formatContext } from "../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+/**
+ * Helper class to abstract error handling in each part of the client reload
+ * process.
+ */
+class ClientReloadPipeline {
+  private client: IClientWithIntentsAndRunners;
+  private context: string;
+
+  constructor(private interaction: ChatInputCommandInteraction) {
+    this.client = interaction.client as IClientWithIntentsAndRunners;
+    this.context = formatContext(interaction);
+  }
+
+  /**
+   * Run the reload pipeline, handling errors and replying the the interaction.
+   *
+   * Postcondition: The interaction will be replied to regardless of success.
+   */
+  public async run(): Promise<void> {
+    const success
+      = await this.clearDefinitions()
+      && await this.deploySlashCommands()
+      && await this.prepareRuntime();
+    if (!success) return;
+
+    await this.interaction.reply({ content: "👍", ephemeral: true });
+    log.warning(`${this.context}: successfully reloaded client.`);
+  }
+
+  private async logAndReplyWithError(error: Error): Promise<void> {
+    console.error(error);
+    const embed = new EmbedBuilder()
+      .setTitle(`Failed to reload client: ${error.name}`)
+      .setDescription(error.message);
+    await this.interaction.reply({
+      embeds: [embed],
+      ephemeral: true,
+    });
+  }
+
+  private async clearDefinitions(): Promise<boolean> {
+    try {
+      this.client.clearDefinitions();
+      return true;
+    }
+    catch (error) {
+      log.crit(`${this.context}: failed to clear definitions.`);
+      await this.logAndReplyWithError(error as Error);
+      return false;
+    }
+  }
+
+  private async deploySlashCommands(): Promise<boolean> {
+    try {
+      await this.client.deploySlashCommands();
+      return true;
+    }
+    catch (error) {
+      log.crit(`${this.context}: failed to deploy slash commands.`);
+      await this.logAndReplyWithError(error as Error);
+      return false;
+    }
+  }
+
+  private async prepareRuntime(): Promise<boolean> {
+    try {
+      await this.client.prepareRuntime();
+      return true;
+    }
+    catch (error) {
+      log.crit(`${this.context}: failed to reload commands and/or listeners.`);
+      await this.logAndReplyWithError(error as Error);
+      return false;
+    }
+  }
+}
+
+const reload = new CommandBuilder();
+
+reload.define(new SlashCommandBuilder()
+  .setName("reload")
+  .setDescription("Reload all commands and event listeners."),
+);
+reload.check(checkPrivilege(RoleLevel.DEV));
+reload.execute(async (interaction) => {
+  await new ClientReloadPipeline(interaction).run();
+});
+
+const reloadSpec = reload.toSpec();
+export default reloadSpec;

--- a/src/controllers/dev/reload.command.ts
+++ b/src/controllers/dev/reload.command.ts
@@ -70,7 +70,7 @@ class ClientReloadPipeline {
 
   private async clearDefinitions(): Promise<boolean> {
     try {
-      this.client.clearDefinitions();
+      await this.client.clearDefinitions();
       return true;
     }
     catch (error) {

--- a/src/controllers/dev/reload.command.ts
+++ b/src/controllers/dev/reload.command.ts
@@ -9,7 +9,7 @@ import {
   RoleLevel,
   checkPrivilege,
 } from "../../middleware/privilege.middleware";
-import { IClientWithIntentsAndRunners } from "../../types/client.abc";
+import { ClientWithIntentsAndRunnersABC } from "../../types/client.abc";
 import { CommandBuilder } from "../../types/command.types";
 import { formatContext } from "../../utils/logging.utils";
 
@@ -20,11 +20,11 @@ const log = getLogger(__filename);
  * process.
  */
 class ClientReloadPipeline {
-  private client: IClientWithIntentsAndRunners;
+  private client: ClientWithIntentsAndRunnersABC;
   private context: string;
 
   constructor(private interaction: ChatInputCommandInteraction) {
-    this.client = interaction.client as IClientWithIntentsAndRunners;
+    this.client = interaction.client as ClientWithIntentsAndRunnersABC;
     this.context = formatContext(interaction);
   }
 

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -111,4 +111,9 @@ export abstract class IClientWithIntentsAndRunners extends Client {
    * expected that this method does NOT start the bot's main runtime.
    */
   public abstract deploySlashCommands(): Promise<void>;
+
+  /**
+   * Undo the setup from `prepareRuntime`.
+   */
+  public abstract clearDefinitions(): void;
 }

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -30,10 +30,10 @@ function getCurrentBranchName(): string | null {
 }
 
 export abstract class IClientWithIntentsAndRunners extends Client {
-  public abstract readonly commandRunners
-    : Collection<string, CommandRunner>;
-  public abstract readonly listenerRunners
-    : Collection<string, ListenerRunner<any>>;
+  public readonly commandRunners
+    = new Collection<string, CommandRunner>();
+  public readonly listenerRunners
+    = new Collection<string, ListenerRunner<any>>();
 
   /**
    * The timestamp since when the bot has been ready. This is to be set by the
@@ -99,4 +99,16 @@ export abstract class IClientWithIntentsAndRunners extends Client {
       log.debug(`registered event listener '${id}'.`);
     }
   }
+
+  /**
+   * Perform any loading and initialization necessary for bot startup. It is
+   * expected that after this method is called, the bot is in a well-defined
+   * state to log in and start its main event loop.
+   */
+  public abstract prepareRuntime(): boolean;
+  /**
+   * Load command definitions and deploy them to Discord's backend. It is
+   * expected that this method does NOT start the bot's main runtime.
+   */
+  public abstract deploySlashCommands(): Promise<void>;
 }

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -105,7 +105,7 @@ export abstract class IClientWithIntentsAndRunners extends Client {
    * expected that after this method is called, the bot is in a well-defined
    * state to log in and start its main event loop.
    */
-  public abstract prepareRuntime(): boolean;
+  public abstract prepareRuntime(): Promise<boolean>;
   /**
    * Load command definitions and deploy them to Discord's backend. It is
    * expected that this method does NOT start the bot's main runtime.
@@ -115,5 +115,5 @@ export abstract class IClientWithIntentsAndRunners extends Client {
   /**
    * Undo the setup from `prepareRuntime`.
    */
-  public abstract clearDefinitions(): void;
+  public abstract clearDefinitions(): Promise<void>;
 }

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -29,7 +29,7 @@ function getCurrentBranchName(): string | null {
   return process.stdout.toString().trim();
 }
 
-export abstract class IClientWithIntentsAndRunners extends Client {
+export abstract class ClientWithIntentsAndRunnersABC extends Client {
   public readonly commandRunners
     = new Collection<string, CommandRunner>();
   public readonly listenerRunners

--- a/src/utils/meta.utils.ts
+++ b/src/utils/meta.utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Similar to `require()`, but using the most updated version of the module
+ * instead of the cached copy.
+ */
+export async function dynamicRequire<
+  ModuleType extends { default: unknown } = { default: unknown }
+>(modulePath: string): Promise<ModuleType> {
+  // Remove the module from the cache.
+  delete require.cache[require.resolve(modulePath)];
+
+  // Use dynamic import to get the updated version.
+  return import(modulePath);
+}

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -19,12 +19,25 @@ it("should require privilege level >= DEV", async () => {
 
 it("should clear defs, deploy commands, and reload defs", async () => {
   const mock = new MockInteraction(reloadSpec)
-    .mockCallerRoles(config.BOT_DEV_RID);
+    .mockCallerRoles(config.BOT_DEV_RID)
+    .mockOption("Boolean", "redeploy_slash_commands", true);
 
   await mock.simulateCommand();
 
   expect(mock.client.clearDefinitions).toHaveBeenCalled();
   expect(mock.client.deploySlashCommands).toHaveBeenCalled();
+  expect(mock.client.prepareRuntime).toHaveBeenCalled();
+  mock.expectRepliedWith({ ephemeral: true });
+});
+
+it("shouldn't deploy commands if option not explicitly set", async () => {
+  const mock = new MockInteraction(reloadSpec)
+    .mockCallerRoles(config.BOT_DEV_RID);
+
+  await mock.simulateCommand();
+
+  expect(mock.client.clearDefinitions).toHaveBeenCalled();
+  expect(mock.client.deploySlashCommands).not.toHaveBeenCalled();
   expect(mock.client.prepareRuntime).toHaveBeenCalled();
   mock.expectRepliedWith({ ephemeral: true });
 });

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -1,0 +1,30 @@
+import config from "../../../src/config";
+import reloadSpec from "../../../src/controllers/dev/reload.command";
+import { MockInteraction } from "../../test-utils";
+
+it("should require privilege level >= DEV", async () => {
+  const mock = new MockInteraction(reloadSpec).mockCallerRoles(config.KAI_RID);
+
+  await mock.simulateCommand();
+
+  expect(mock.client.clearDefinitions).not.toHaveBeenCalled();
+  expect(mock.client.deploySlashCommands).not.toHaveBeenCalled();
+  expect(mock.client.prepareRuntime).not.toHaveBeenCalled();
+  mock.expectRepliedWith({
+    // Any mention of the DEV level.
+    content: expect.stringMatching(/\bDEV\b/i),
+    ephemeral: true,
+  });
+});
+
+it("should clear defs, deploy commands, and reload defs", async () => {
+  const mock = new MockInteraction(reloadSpec)
+    .mockCallerRoles(config.BOT_DEV_RID);
+
+  await mock.simulateCommand();
+
+  expect(mock.client.clearDefinitions).toHaveBeenCalled();
+  expect(mock.client.deploySlashCommands).toHaveBeenCalled();
+  expect(mock.client.prepareRuntime).toHaveBeenCalled();
+  mock.expectRepliedWith({ ephemeral: true });
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -18,7 +18,7 @@ import { fromZodError } from "zod-validation-error";
 
 import { CommandRunner } from "../src/bot/command.runner";
 import { ListenerRunner } from "../src/bot/listener.runner";
-import { IClientWithIntentsAndRunners } from "../src/types/client.abc";
+import { ClientWithIntentsAndRunnersABC } from "../src/types/client.abc";
 import { CommandSpec } from "../src/types/command.types";
 import { ListenerSpec } from "../src/types/listener.types";
 
@@ -70,7 +70,7 @@ export class MockInteraction {
    *
    * Mock the client attached to the interaction.
    */
-  public mockClient(client: IClientWithIntentsAndRunners): this {
+  public mockClient(client: ClientWithIntentsAndRunnersABC): this {
     addMockGetter(this.interaction, "client", client);
     return this;
   }
@@ -184,7 +184,7 @@ export function addMockGetter<ObjectType extends object, ValueType>(
  * A client stub for testing. Its public interface has been replaced with Jest
  * mocks.
  */
-export class TestClient extends IClientWithIntentsAndRunners {
+export class TestClient extends ClientWithIntentsAndRunnersABC {
   public override deploySlashCommands = jest.fn();
   public override prepareRuntime = jest.fn();
   public override clearDefinitions = jest.fn();

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -1,7 +1,6 @@
 import {
   Awaitable,
   ChatInputCommandInteraction,
-  Collection,
   CommandInteractionOptionResolver,
   EmojiIdentifierResolvable,
   Events,
@@ -175,11 +174,13 @@ export function addMockGetter<ObjectType extends object, ValueType>(
   return mockGetter;
 }
 
+/**
+ * A client stub for testing. Its public interface has been replaced with Jest
+ * mocks.
+ */
 export class TestClient extends IClientWithIntentsAndRunners {
-  public override readonly commandRunners
-    = new Collection<string, CommandRunner>();
-  public override readonly listenerRunners
-    = new Collection<string, ListenerRunner<any>>();
+  public override deploySlashCommands = jest.fn();
+  public override prepareRuntime = jest.fn();
 }
 
 /**

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -181,6 +181,7 @@ export function addMockGetter<ObjectType extends object, ValueType>(
 export class TestClient extends IClientWithIntentsAndRunners {
   public override deploySlashCommands = jest.fn();
   public override prepareRuntime = jest.fn();
+  public override clearDefinitions = jest.fn();
 }
 
 /**

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -43,10 +43,16 @@ export class MockInteraction {
   public readonly interaction: DeepMockProxy<ChatInputCommandInteraction>;
   /** The command this interaction is to be passed into. */
   public readonly command: CommandRunner;
+  /** The client stub attached to the mock interaction. */
+  public readonly client: TestClient;
 
   constructor(spec: CommandSpec) {
     this.interaction = mockDeep<ChatInputCommandInteraction>();
     this.command = new CommandRunner(spec);
+
+    // Override attached client with stub.
+    this.client = new TestClient();
+    addMockGetter(this.interaction, "client", this.client);
   }
 
   /**

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -44,14 +44,14 @@ export class MockInteraction {
   /** The command this interaction is to be passed into. */
   public readonly command: CommandRunner;
   /** The client stub attached to the mock interaction. */
-  public readonly client: TestClient;
+  public readonly client: DeepMockProxy<TestClient>;
 
   constructor(spec: CommandSpec) {
     this.interaction = mockDeep<ChatInputCommandInteraction>();
     this.command = new CommandRunner(spec);
 
     // Override attached client with stub.
-    this.client = new TestClient();
+    this.client = mockDeep<TestClient>();
     addMockGetter(this.interaction, "client", this.client);
   }
 


### PR DESCRIPTION
This PR introduces a `/reload` command that allows bot developers to dynamically reload the commands and event listeners after startup. In other words, `/reload` acts as a front-end for re-calling `BotClient`'s existing `deploySlashCommands` and `prepareRuntime` methods.

To preserve SRP, the abstract interface of `ClientWithIntentsAndRunnersABC` (renamed from `IClientWithIntentsAndRunners` to be consistent with the interface vs. ABC distinction implied in #6) was updated with the following `abstract` methods:

* `deploySlashCommands`
* `prepareRuntime`
* `clearDefinitions`

**Other changes:**
* Also removed the `abstract` qualifier from `commandRunners` and `listenerRunners` in `ClientWithIntentsAndRunnersABC` since there was no point in them being `abstract`; they have default initializers within the ABC now.
* A `dynamicRequire()` helper that acts like `require()` but forces the loading of the most updated version of the module as opposed to using the cache. This replaces the `require()` statements in `CommandLoader` & `ListenerLoader` and is the reason monkey patching is possible in the first place.
* `MockInteraction` now exposes a deeply mocked `TestClient` for `ChatInputCommandInteraction#client`.
* Client subclasses now implement a `clearDefinitions` method, which serves as a way to clean up commands/listeners prior to reloading. This is necessary because we want the reload to be a *full* reset and not an additive one (if a module was deleted prior to reloading, it should no longer exist in the new client state instead of still being there due to not being removed).