### PR TITLE
Minorly fix dynamic reload feature

### DIFF
--- a/src/controllers/dev/reload.command.ts
+++ b/src/controllers/dev/reload.command.ts
@@ -74,7 +74,7 @@ class ClientReloadPipeline {
       return true;
     }
     catch (error) {
-      log.crit(`${this.context}: failed to clear definitions.`);
+      log.crit(`${this.context}: error in clearing definitions.`);
       await this.logAndReplyWithError(error as Error);
       return false;
     }
@@ -86,7 +86,7 @@ class ClientReloadPipeline {
       return true;
     }
     catch (error) {
-      log.crit(`${this.context}: failed to deploy slash commands.`);
+      log.crit(`${this.context}: error in deploying slash commands.`);
       await this.logAndReplyWithError(error as Error);
       return false;
     }
@@ -94,14 +94,21 @@ class ClientReloadPipeline {
 
   private async prepareRuntime(): Promise<boolean> {
     try {
-      await this.client.prepareRuntime();
-      return true;
+      if (await this.client.prepareRuntime()) return true;
     }
     catch (error) {
-      log.crit(`${this.context}: failed to reload commands and/or listeners.`);
+      log.crit(`${this.context}: error in reloading commands/listeners.`);
       await this.logAndReplyWithError(error as Error);
       return false;
     }
+    // No error, but prepareRuntime reported failure.
+    log.crit(`${this.context}: failed to reload commands/listeners.`);
+    const customError = new Error(
+      "No exception was raised when reloading commands and/or listeners, " +
+      "but the process reported failure. Check the logs.",
+    );
+    await this.logAndReplyWithError(customError);
+    return false;
   }
 }
 

--- a/src/controllers/dev/reload.command.ts
+++ b/src/controllers/dev/reload.command.ts
@@ -12,6 +12,7 @@ import {
 import { ClientWithIntentsAndRunnersABC } from "../../types/client.abc";
 import { CommandBuilder } from "../../types/command.types";
 import { formatContext } from "../../utils/logging.utils";
+import { getCurrentBranchName } from "../../utils/meta.utils";
 
 const log = getLogger(__filename);
 
@@ -39,6 +40,8 @@ class ClientReloadPipeline {
   public async run(redeploy: boolean): Promise<void> {
     log.warning(`${this.context}: reloading client (redeploy=${redeploy})...`);
 
+    const branchName = getCurrentBranchName();
+
     let success: boolean;
     if (redeploy) {
       success
@@ -52,6 +55,9 @@ class ClientReloadPipeline {
         && await this.prepareRuntime();
     }
     if (!success) return;
+
+    this.client.branchName = branchName;
+    log.info(`${this.context}: updated client branch name to '${branchName}'.`);
 
     await this.interaction.reply({ content: "👍", ephemeral: true });
     log.warning(`${this.context}: successfully reloaded client.`);

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -103,7 +103,8 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
   /**
    * Perform any loading and initialization necessary for bot startup. It is
    * expected that after this method is called, the bot is in a well-defined
-   * state to log in and start its main event loop.
+   * state to log in and start its main event loop. Return whether the operation
+   * succeeded.
    */
   public abstract prepareRuntime(): Promise<boolean>;
   /**
@@ -111,7 +112,6 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
    * expected that this method does NOT start the bot's main runtime.
    */
   public abstract deploySlashCommands(): Promise<void>;
-
   /**
    * Undo the setup from `prepareRuntime`.
    */

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -1,5 +1,3 @@
-import child_process from "node:child_process";
-
 import {
   Client,
   Collection,
@@ -11,23 +9,10 @@ import {
 import { CommandRunner } from "../bot/command.runner";
 import { ListenerRunner } from "../bot/listener.runner";
 import getLogger from "../logger";
+import { getCurrentBranchName } from "../utils/meta.utils";
 import { ListenerFilter } from "./listener.types";
 
 const log = getLogger(__filename);
-
-function getCurrentBranchName(): string | null {
-  const command = "git rev-parse --abbrev-ref HEAD";
-  const process = child_process.spawnSync(command, { shell: true });
-  if (process.status !== 0) {
-    const stderr = process.stderr?.toString().trim();
-    log.warning(
-      `\`${command}\` failed with exit code ${process.status}` +
-      (stderr ? `: ${stderr}` : ""),
-    );
-    return null;
-  }
-  return process.stdout.toString().trim();
-}
 
 export abstract class ClientWithIntentsAndRunnersABC extends Client {
   public readonly commandRunners
@@ -45,7 +30,7 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
    * Name of the Git branch that was checked out when this program was started.
    * This value is `null` if no Git repository is detected.
    */
-  public readonly branchName = getCurrentBranchName();
+  public branchName = getCurrentBranchName();
 
   constructor() {
     super({

--- a/src/utils/meta.utils.ts
+++ b/src/utils/meta.utils.ts
@@ -1,3 +1,9 @@
+import child_process from "node:child_process";
+
+import getLogger from "../logger";
+
+const log = getLogger(__filename);
+
 /**
  * Similar to `require()`, but using the most updated version of the module
  * instead of the cached copy.
@@ -10,4 +16,22 @@ export async function dynamicRequire<
 
   // Use dynamic import to get the updated version.
   return import(modulePath);
+}
+
+/**
+ * Get the current Git branch name. Return `null` if the Git command fails,
+ * likely because no repository was detected.
+ */
+export function getCurrentBranchName(): string | null {
+  const command = "git rev-parse --abbrev-ref HEAD";
+  const process = child_process.spawnSync(command, { shell: true });
+  if (process.status !== 0) {
+    const stderr = process.stderr?.toString().trim();
+    log.warning(
+      `\`${command}\` failed with exit code ${process.status}` +
+      (stderr ? `: ${stderr}` : ""),
+    );
+    return null;
+  }
+  return process.stdout.toString().trim();
 }

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -1,9 +1,14 @@
+jest.mock("../../../src/utils/meta.utils");
+
 import { EmbedBuilder } from "discord.js";
 import { Matcher } from "jest-mock-extended";
 
 import config from "../../../src/config";
 import reloadSpec from "../../../src/controllers/dev/reload.command";
+import { getCurrentBranchName } from "../../../src/utils/meta.utils";
 import { MockInteraction } from "../../test-utils";
+
+const mockedGetCurrentBranchName = jest.mocked(getCurrentBranchName);
 
 let mock: MockInteraction;
 
@@ -52,6 +57,15 @@ it("shouldn't deploy commands if option not explicitly set", async () => {
   expect(mock.client.deploySlashCommands).not.toHaveBeenCalled();
   expect(mock.client.prepareRuntime).toHaveBeenCalled();
   mock.expectRepliedWith({ ephemeral: true });
+});
+
+it("should update the client's branch name", async () => {
+  mock.mockCallerRoles(config.BOT_DEV_RID);
+  mockedGetCurrentBranchName.mockReturnValueOnce("DUMMY-BRANCH-NAME");
+
+  await mock.simulateCommand();
+
+  expect(mock.client.branchName).toEqual("DUMMY-BRANCH-NAME");
 });
 
 describe("error handling", () => {

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -5,8 +5,18 @@ import config from "../../../src/config";
 import reloadSpec from "../../../src/controllers/dev/reload.command";
 import { MockInteraction } from "../../test-utils";
 
+let mock: MockInteraction;
+
+beforeEach(() => {
+  mock = new MockInteraction(reloadSpec);
+
+  // Need to explicitly specify a return value (otherwise the falsy undefined
+  // is used at runtime).
+  mock.client.prepareRuntime.mockResolvedValue(true);
+});
+
 it("should require privilege level >= DEV", async () => {
-  const mock = new MockInteraction(reloadSpec).mockCallerRoles(config.KAI_RID);
+  mock.mockCallerRoles(config.KAI_RID);
 
   await mock.simulateCommand();
 
@@ -21,7 +31,7 @@ it("should require privilege level >= DEV", async () => {
 });
 
 it("should clear defs, deploy commands, and reload defs", async () => {
-  const mock = new MockInteraction(reloadSpec)
+  mock
     .mockCallerRoles(config.BOT_DEV_RID)
     .mockOption("Boolean", "redeploy_slash_commands", true);
 
@@ -34,8 +44,7 @@ it("should clear defs, deploy commands, and reload defs", async () => {
 });
 
 it("shouldn't deploy commands if option not explicitly set", async () => {
-  const mock = new MockInteraction(reloadSpec)
-    .mockCallerRoles(config.BOT_DEV_RID);
+  mock.mockCallerRoles(config.BOT_DEV_RID);
 
   await mock.simulateCommand();
 
@@ -46,10 +55,8 @@ it("shouldn't deploy commands if option not explicitly set", async () => {
 });
 
 describe("error handling", () => {
-  let mock: MockInteraction;
-
   beforeEach(() => {
-    mock = new MockInteraction(reloadSpec)
+    mock
       .mockCallerRoles(config.BOT_DEV_RID)
       .mockOption("Boolean", "redeploy_slash_commands", true);
 
@@ -95,4 +102,17 @@ describe("error handling", () => {
       }
     });
   }
+
+  it("should false from prepareRuntime as a failure", async () => {
+    mock.client.prepareRuntime.mockResolvedValueOnce(false);
+
+    await mock.simulateCommand();
+
+    expect(mock.client.prepareRuntime).toHaveBeenCalled(); // Or else pointless.
+    mock.expectRepliedWith({
+      // A custom error is raised internally.
+      embeds: expect.arrayContaining([expect.any(EmbedBuilder)]),
+      ephemeral: true,
+    });
+  });
 });


### PR DESCRIPTION
Minor fixes to dynamic `/reload` feature introduced in #63:

1. Fix (and cover the case in tests) the case of `ClientWithIntentsAndRunnersABC#prepareRuntime` returning `false` for failure instead of erroring.
2. Make `/reload` also update the reported Git branch name too. This involved moving the `getCurrentBranchName` helper out of `client.abc.ts` (it didn't feel like it really belonged there anyway) into `meta.utils.ts`.

