### PR TITLE
Fix nondeterministic test failures

### DIFF
--- a/tests/controllers/users/cxtie/sniffs.listener.test.ts
+++ b/tests/controllers/users/cxtie/sniffs.listener.test.ts
@@ -4,11 +4,11 @@ import {
   GUILD_EMOJIS,
   toEscapedEmoji,
 } from "../../../../src/utils/emojis.utils";
-import { MockMessage } from "../../../test-utils";
+import { MockMessage, spyOnRandom } from "../../../test-utils";
 
 describe("sniffs listener", () => {
   afterEach(() => {
-    jest.spyOn(global.Math, "random").mockRestore();
+    spyOnRandom().mockRestore();
   });
 
   it("should only listen to Cxtie", async () => {
@@ -21,7 +21,7 @@ describe("sniffs listener", () => {
     const mock = new MockMessage(onSniffsSpec)
       .mockContent("sniffs")
       .mockAuthor({ uid: config.CXTIE_UID });
-    jest.spyOn(global.Math, "random").mockReturnValueOnce(0.99);
+    spyOnRandom().mockReturnValueOnce(0.99);
     await mock.simulateEvent();
     mock.expectRepliedSilentlyWith({ content: "sniffs" });
   });
@@ -30,7 +30,7 @@ describe("sniffs listener", () => {
     const mock = new MockMessage(onSniffsSpec)
       .mockContent("sniffs")
       .mockAuthor({ uid: config.CXTIE_UID });
-    jest.spyOn(global.Math, "random").mockReturnValueOnce(0);
+    spyOnRandom().mockReturnValueOnce(0);
     await mock.simulateEvent();
     mock.expectRepliedSilentlyWith({ content: "daily cxtie appreciation" });
   });
@@ -43,7 +43,7 @@ describe("sniffs listener", () => {
     const mock = new MockMessage(onSniffsSpec)
       .mockContent(`You ${sniffsEmoji} make me cry ${sniffsEmoji}!`)
       .mockAuthor({ uid: config.CXTIE_UID });
-    jest.spyOn(global.Math, "random").mockReturnValueOnce(0.99);
+    spyOnRandom().mockReturnValueOnce(0.99);
 
     await mock.simulateEvent();
 

--- a/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
+++ b/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
@@ -44,7 +44,7 @@ describe("anti-cxtie listener", () => {
       mockReactChanceGetter
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
-      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.50);
+      jest.spyOn(global.Math, "random").mockReturnValue(0.50);
 
       await mock.simulateEvent();
       mock.expectNotResponded();

--- a/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
+++ b/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
@@ -4,7 +4,7 @@ import config from "../../../../src/config";
 import randomReacterSpec from "../../../../src/controllers/users/cxtie/timer-reacter.listener";
 import cxtieService from "../../../../src/services/cxtie.service";
 import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
-import { MockMessage, addMockGetter } from "../../../test-utils";
+import { MockMessage, addMockGetter, spyOnRandom } from "../../../test-utils";
 
 const mockedCxtieService = jest.mocked(cxtieService);
 const mockReactChanceGetter = jest.fn();
@@ -17,14 +17,10 @@ describe("anti-cxtie listener", () => {
       .mockAuthor({ uid: config.CXTIE_UID });
   });
 
-  afterEach(() => {
-    jest.spyOn(global.Math, "random").mockRestore();
-  });
-
   describe("should react randomly based on chance computed by service", () => {
     it("should meow", async () => {
       mockReactChanceGetter.mockReturnValueOnce(0.05);
-      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.01);
+      spyOnRandom().mockReturnValueOnce(0.01);
 
       await mock.simulateEvent();
 
@@ -33,7 +29,7 @@ describe("anti-cxtie listener", () => {
 
     it("shouldn't react", async () => {
       mockReactChanceGetter.mockReturnValueOnce(0.05);
-      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.42);
+      spyOnRandom().mockReturnValueOnce(0.42);
 
       await mock.simulateEvent();
 
@@ -44,7 +40,7 @@ describe("anti-cxtie listener", () => {
       mockReactChanceGetter
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
-      jest.spyOn(global.Math, "random").mockReturnValue(0.50);
+      spyOnRandom().mockReturnValue(0.50);
 
       await mock.simulateEvent();
       mock.expectNotResponded();

--- a/tests/controllers/users/luke/random-meow.listener.test.ts
+++ b/tests/controllers/users/luke/random-meow.listener.test.ts
@@ -41,7 +41,7 @@ describe("random-meow listener", () => {
       mockedLukeService.getMeowChance
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
-      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.50);
+      jest.spyOn(global.Math, "random").mockReturnValue(0.50);
 
       await mock.simulateEvent();
       mock.expectNotResponded();

--- a/tests/controllers/users/luke/random-meow.listener.test.ts
+++ b/tests/controllers/users/luke/random-meow.listener.test.ts
@@ -3,7 +3,7 @@ jest.mock("../../../../src/services/luke.service");
 import config from "../../../../src/config";
 import randomMeowerSpec from "../../../../src/controllers/users/luke/random-meow.listener";
 import lukeService from "../../../../src/services/luke.service";
-import { MockMessage } from "../../../test-utils";
+import { MockMessage, spyOnRandom } from "../../../test-utils";
 
 const mockedLukeService = jest.mocked(lukeService);
 
@@ -14,14 +14,10 @@ describe("random-meow listener", () => {
       .mockAuthor({ uid: config.LUKE_UID });
   });
 
-  afterEach(() => {
-    jest.spyOn(global.Math, "random").mockRestore();
-  });
-
   describe("should meow randomly based on chance computed by service", () => {
     it("should meow", async () => {
       mockedLukeService.getMeowChance.mockReturnValueOnce(0.05);
-      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.01);
+      spyOnRandom().mockReturnValueOnce(0.01);
 
       await mock.simulateEvent();
 
@@ -30,7 +26,7 @@ describe("random-meow listener", () => {
 
     it("shouldn't meow", async () => {
       mockedLukeService.getMeowChance.mockReturnValueOnce(0.05);
-      jest.spyOn(global.Math, "random").mockReturnValueOnce(0.42);
+      spyOnRandom().mockReturnValueOnce(0.42);
 
       await mock.simulateEvent();
 
@@ -41,7 +37,7 @@ describe("random-meow listener", () => {
       mockedLukeService.getMeowChance
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
-      jest.spyOn(global.Math, "random").mockReturnValue(0.50);
+      spyOnRandom().mockReturnValue(0.50);
 
       await mock.simulateEvent();
       mock.expectNotResponded();

--- a/tests/middleware/filters.middleware.test.ts
+++ b/tests/middleware/filters.middleware.test.ts
@@ -25,7 +25,7 @@ import {
   // @ts-expect-error We injected this.
   realIsPollutionImmuneChannel,
 } from "../../src/middleware/filters.middleware";
-import { mockRandomReturnValueOnce, restoreRandomSpy } from "../test-utils";
+import { mockRandomReturnValueOnce } from "../test-utils";
 
 const mockedIsPollutionImmuneChannel = jest.mocked(isPollutionImmuneChannel);
 
@@ -154,8 +154,6 @@ describe("contentMatching middleware", () => {
 
 describe("randomly middleware", () => {
   const message = {} as Message;
-
-  afterEach(restoreRandomSpy);
 
   describe("using a constant success chance", () => {
     const closure = randomly(0.42);

--- a/tests/middleware/filters.middleware.test.ts
+++ b/tests/middleware/filters.middleware.test.ts
@@ -25,7 +25,7 @@ import {
   // @ts-expect-error We injected this.
   realIsPollutionImmuneChannel,
 } from "../../src/middleware/filters.middleware";
-import { mockRandomReturnValueOnce } from "../test-utils";
+import { spyOnRandom } from "../test-utils";
 
 const mockedIsPollutionImmuneChannel = jest.mocked(isPollutionImmuneChannel);
 
@@ -159,13 +159,13 @@ describe("randomly middleware", () => {
     const closure = randomly(0.42);
 
     it("should pass", async () => {
-      mockRandomReturnValueOnce(0.05);
+      spyOnRandom().mockReturnValueOnce(0.05);
       const passed = await closure(message);
       expect(passed).toEqual(true);
     });
 
     it("should not pass", async () => {
-      mockRandomReturnValueOnce(0.95);
+      spyOnRandom().mockReturnValueOnce(0.95);
       const passed = await closure(message);
       expect(passed).toEqual(false);
     });
@@ -177,14 +177,14 @@ describe("randomly middleware", () => {
 
     it("should pass with callback returning 0.5", async () => {
       dynamicSuccessChance.mockReturnValueOnce(0.5);
-      mockRandomReturnValueOnce(0.05);
+      spyOnRandom().mockReturnValueOnce(0.05);
       const passed = await closure(message);
       expect(passed).toEqual(true);
     });
 
     it("should pass with callback returning 0.01", async () => {
       dynamicSuccessChance.mockReturnValueOnce(0.01);
-      mockRandomReturnValueOnce(0.05);
+      spyOnRandom().mockReturnValueOnce(0.05);
       const passed = await closure(message);
       expect(passed).toEqual(false);
     });

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -486,8 +486,17 @@ export function expectMatchingSchema(
 }
 
 /**
+ * @deprecated Use `spyOnRandom` instead.
+ *
  * Mock the next return value of `Math.random()`.
  */
 export function mockRandomReturnValueOnce(returnValue: number): void {
   jest.spyOn(global.Math, "random").mockReturnValueOnce(returnValue);
+}
+
+/**
+ * Return a spy instance for `Math.random`.
+ */
+export function spyOnRandom(): jest.SpyInstance {
+  return jest.spyOn(global.Math, "random");
 }

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -486,15 +486,6 @@ export function expectMatchingSchema(
 }
 
 /**
- * @deprecated Use `spyOnRandom` instead.
- *
- * Mock the next return value of `Math.random()`.
- */
-export function mockRandomReturnValueOnce(returnValue: number): void {
-  jest.spyOn(global.Math, "random").mockReturnValueOnce(returnValue);
-}
-
-/**
  * Return a spy instance for `Math.random`.
  */
 export function spyOnRandom(): jest.SpyInstance {

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -487,16 +487,7 @@ export function expectMatchingSchema(
 
 /**
  * Mock the next return value of `Math.random()`.
- *
- * Postcondition: the Jest spy on `Math.random` is restored sometime afterwards.
  */
 export function mockRandomReturnValueOnce(returnValue: number): void {
   jest.spyOn(global.Math, "random").mockReturnValueOnce(returnValue);
-}
-
-/**
- * Restore spying on `Math.random`.
- */
-export function restoreRandomSpy(): void {
-  jest.spyOn(global.Math, "random").mockRestore();
 }

--- a/tests/utils/math.utils.test.ts
+++ b/tests/utils/math.utils.test.ts
@@ -1,12 +1,9 @@
 import { randRange } from "../../src/utils/math.utils";
+import { spyOnRandom } from "../test-utils";
 
 describe("generating a random integer within a range", () => {
   beforeEach(() => {
-    jest.spyOn(global.Math, "random").mockReturnValue(0.50);
-  });
-
-  afterEach(() => {
-    jest.spyOn(global.Math, "random").mockRestore();
+    spyOnRandom().mockReturnValue(0.50);
   });
 
   it("should reject lower bounds that aren't integers", () => {


### PR DESCRIPTION
## Context

The tests for dynamic anti-Cxtie react chance and random meowing chance were strangely nondeterministic. The vast majority of the time they would pass, but there were a couple of times where they failed for no apparent reason. One recorded example is [this workflow run](https://github.com/vinlin24/yungkaiworldbot/actions/runs/7479443105/job/20356630780), which succeeded upon rerunning without changing anything.


## Cause Identified

It turns out it was because both of those tests were making two calls to `Math.random()`, but the return value of `Math.random` was only mocked once. The second chance being tested was 0.95, so the unmocked `Math.random()` returned a passing chance by pure chance 95% of the time, explaining why the tests only rarely failed.


## Changelog

* Fixed the aforementioned issue by using `mockReturnValue` instead of `mockReturnValueOnce`.
* Removed `restoreRandomSpy`, which was actually never needed. `clearMocks: true` also applies to spies, so Jest spies are automatically reset before every test, so there's no need to remember to use `.mockRestore()`.
* Refactored `jest.spyOn(global.Math, "random")` into a helper, `spyOnRandom()`.
* Removed `mockRandomReturnValueOnce` in favor of using `spyOnRandom()` and then chaining the `mock*` methods on that instead.