### PR TITLE
Add check that TS can compile src in PR workflow

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -48,3 +48,6 @@ jobs:
 
       - name: Run linter
         run: npm run lint
+
+      - name: Check that TypeScript can compile
+        run: npm run build


### PR DESCRIPTION
There have been times where both the tests and the linter would pass, but actually running the program reveals a TypeScript error (usually due to a refactoring causing some type error or unidentified symbol/import error in a file not directly related to the changes). This step would check that the code can actually pass the TypeScript compiler.