### PR TITLE
Fix hello world response not pinging Taco

### DIFF
--- a/src/controllers/users/s/hello-world.listener.ts
+++ b/src/controllers/users/s/hello-world.listener.ts
@@ -15,7 +15,10 @@ helloWorld.execute(async (message) => {
   const tacoMention = toUserMention(config.TACO_UID);
   await message.reply({
     content: tacoMention,
-    allowedMentions: { repliedUser: false }, // But do allow Taco mention!
+    allowedMentions: {
+      repliedUser: false,
+      users: [config.TACO_UID],
+    },
     flags: MessageFlags.SuppressNotifications,
   });
 });

--- a/tests/controllers/users/s/hello-world.listener.test.ts
+++ b/tests/controllers/users/s/hello-world.listener.test.ts
@@ -1,4 +1,5 @@
-import { MessageFlags } from "discord.js";
+import { MessageFlags, MessageMentionOptions } from "discord.js";
+
 import config from "../../../../src/config";
 import helloWorldSpec from "../../../../src/controllers/users/s/hello-world.listener";
 import { toUserMention } from "../../../../src/utils/markdown.utils";
@@ -13,7 +14,10 @@ it("should ping Taco when S sends hello world", async () => {
 
   mock.expectRepliedWith({
     content: expect.stringContaining(toUserMention(config.TACO_UID)),
-    allowedMentions: expect.objectContaining({ repliedUser: false }),
+    allowedMentions: expect.objectContaining<MessageMentionOptions>({
+      repliedUser: false,
+      users: expect.arrayContaining([config.TACO_UID]),
+    }),
     flags: MessageFlags.SuppressNotifications,
   });
 });


### PR DESCRIPTION
Fix to #62.

It turns out `allowedMentions.repliedUser: false` disables all other mentions as well. We need to specify with `allowedMentions.users` the UIDs of users that can be mentioned.