### PR TITLE
Refactor misc, remove redundant & deprecated funcs

### DIFF
--- a/src/controllers/convenience/countdown.command.ts
+++ b/src/controllers/convenience/countdown.command.ts
@@ -1,4 +1,8 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  SlashCommandBuilder,
+  userMention,
+} from "discord.js";
 import parseDuration from "parse-duration";
 
 import getLogger from "../../logger";
@@ -8,10 +12,7 @@ import {
   formatHoursMinsSeconds,
 } from "../../utils/dates.utils";
 import { formatContext } from "../../utils/logging.utils";
-import {
-  toRelativeTimestampMention,
-  toUserMention,
-} from "../../utils/markdown.utils";
+import { toRelativeTimestampMention } from "../../utils/markdown.utils";
 import { addEphemeralOption } from "../../utils/options.utils";
 
 const log = getLogger(__filename);
@@ -61,7 +62,7 @@ async function startCountdown(
 
   const endTimestamp = addDateSeconds(new Date(), seconds);
   setTimeout(async () => {
-    const mention = toUserMention(interaction.member!.user.id);
+    const mention = userMention(interaction.member!.user.id);
     log.debug(`${context}: countdown from ${seconds} ago expired.`);
     await interaction.channel!.send(`${mention}, your countdown has expired!`);
   }, seconds * 1000);

--- a/src/controllers/dev/cooldowns/list-cooldowns.command.ts
+++ b/src/controllers/dev/cooldowns/list-cooldowns.command.ts
@@ -1,5 +1,12 @@
 import { pagination } from "@devraelfreeze/discordjs-pagination";
-import { EmbedBuilder, Events, SlashCommandBuilder, User } from "discord.js";
+import {
+  EmbedBuilder,
+  Events,
+  SlashCommandBuilder,
+  User,
+  channelMention,
+  userMention,
+} from "discord.js";
 
 import { BotClient } from "../../../bot/client";
 import getLogger from "../../../logger";
@@ -16,10 +23,8 @@ import { formatContext } from "../../../utils/logging.utils";
 import {
   joinUserMentions,
   toBulletedList,
-  toChannelMention,
   toRelativeTimestampMention,
   toTimestampMention,
-  toUserMention,
 } from "../../../utils/markdown.utils";
 import { addBroadcastOption } from "../../../utils/options.utils";
 import { listenerIdAutocomplete } from "./cooldowns.autocomplete";
@@ -92,14 +97,14 @@ function formatPerUserCooldownDump(
   now: Date,
   dump: PerUserCooldownDump,
 ): string {
-  return formatPerIDCooldownDump(now, dump, toUserMention, "PER-USER");
+  return formatPerIDCooldownDump(now, dump, userMention, "PER-USER");
 }
 
 function formatPerChannelCooldownDump(
   now: Date,
   dump: PerChannelCooldownDump,
 ): string {
-  return formatPerIDCooldownDump(now, dump, toChannelMention, "PER-CHANNEL");
+  return formatPerIDCooldownDump(now, dump, channelMention, "PER-CHANNEL");
 }
 
 function formatListenerCooldownDump(

--- a/src/controllers/dev/cooldowns/list-cooldowns.command.ts
+++ b/src/controllers/dev/cooldowns/list-cooldowns.command.ts
@@ -3,8 +3,10 @@ import {
   EmbedBuilder,
   Events,
   SlashCommandBuilder,
+  TimestampStyles,
   User,
   channelMention,
+  time,
   userMention,
 } from "discord.js";
 
@@ -23,8 +25,6 @@ import { formatContext } from "../../../utils/logging.utils";
 import {
   joinUserMentions,
   toBulletedList,
-  toRelativeTimestampMention,
-  toTimestampMention,
 } from "../../../utils/markdown.utils";
 import { addBroadcastOption } from "../../../utils/options.utils";
 import { listenerIdAutocomplete } from "./cooldowns.autocomplete";
@@ -38,8 +38,8 @@ const MAX_DESCRIPTION_LENGTH = 4096;
 
 function formatStatus(now: Date, expiration: Date): string {
   if (now >= expiration) return "Inactive ✅";
-  const mention = toTimestampMention(expiration);
-  const relativeMention = toRelativeTimestampMention(expiration);
+  const mention = time(expiration);
+  const relativeMention = time(expiration, TimestampStyles.RelativeTime);
   return `Active until ${mention} (${relativeMention}) ⌛`;
 }
 

--- a/src/controllers/dev/ping.command.ts
+++ b/src/controllers/dev/ping.command.ts
@@ -1,12 +1,13 @@
-import { ChatInputCommandInteraction, SlashCommandBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  SlashCommandBuilder,
+  TimestampStyles,
+  time,
+} from "discord.js";
 
 import { CommandBuilder, CommandSpec } from "../../types/command.types";
 
 import { ClientWithIntentsAndRunnersABC } from "../../types/client.abc";
-import {
-  toRelativeTimestampMention,
-  toTimestampMention,
-} from "../../utils/markdown.utils";
 import { addBroadcastOption } from "../../utils/options.utils";
 
 const slashCommandDefinition = new SlashCommandBuilder()
@@ -42,8 +43,8 @@ async function respondWithDevDetails(
   }
 
   if (readySince) {
-    const timestamp = toTimestampMention(readySince);
-    const relativeTimestamp = toRelativeTimestampMention(readySince);
+    const timestamp = time(readySince);
+    const relativeTimestamp = time(readySince, TimestampStyles.RelativeTime);
     text += `\n* Ready: ${timestamp} (${relativeTimestamp})`;
   }
 

--- a/src/controllers/users/coffee/uff.listener.ts
+++ b/src/controllers/users/coffee/uff.listener.ts
@@ -2,10 +2,6 @@ import { Events } from "discord.js";
 
 import config from "../../../config";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   contentMatching,
   messageFrom,
 } from "../../../middleware/filters.middleware";
@@ -15,16 +11,13 @@ import {
 } from "../../../types/listener.types";
 import { replySilentlyWith } from "../../../utils/interaction.utils";
 
-const cooldown = new CooldownManager({ type: "global", seconds: 600 });
-
 const uffSpec: ListenerSpec<Events.MessageCreate>
   = new MessageListenerBuilder()
     .setId("uff")
     .filter(messageFrom(config.COFFEE_UID))
-    .filter(contentMatching(/^uff$/i))
+    .filter(contentMatching(/^uff+$/i))
     .execute(replySilentlyWith("woof"))
-    .filter(useCooldown(cooldown))
-    .saveCooldown(cooldown)
+    .cooldown({ type: "global", seconds: 600 })
     .toSpec();
 
 export default uffSpec;

--- a/src/controllers/users/coffee/uwu.listener.ts
+++ b/src/controllers/users/coffee/uwu.listener.ts
@@ -2,10 +2,6 @@ import { Events, Message } from "discord.js";
 
 import config from "../../../config";
 import getLogger from "../../../logger";
-import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
 import { contentMatching } from "../../../middleware/filters.middleware";
 import {
   ListenerSpec,
@@ -21,19 +17,16 @@ async function reactWithVomit(message: Message) {
   log.debug(`${formatContext(message)}: reacted to uwu.`);
 }
 
-const cooldown = new CooldownManager({
-  type: "global",
-  seconds: 10,
-  bypassers: [config.COFFEE_UID],
-});
-
 const uwuSpec: ListenerSpec<Events.MessageCreate>
   = new MessageListenerBuilder()
     .setId("uwu")
-    .filter(contentMatching(/^uwu$/i))
+    .filter(contentMatching(/^uwu+$/i))
     .execute(reactWithVomit)
-    .filter(useCooldown(cooldown))
-    .saveCooldown(cooldown)
+    .cooldown({
+      type: "global",
+      seconds: 10,
+      bypassers: [config.COFFEE_UID],
+    })
     .toSpec();
 
 export default uwuSpec;

--- a/src/controllers/users/cxtie/chat-revive.listener.ts
+++ b/src/controllers/users/cxtie/chat-revive.listener.ts
@@ -3,10 +3,6 @@ import { Events, Message } from "discord.js";
 import config from "../../../config";
 import getLogger from "../../../logger";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   ListenerSpec,
   MessageListenerBuilder,
 } from "../../../types/listener.types";
@@ -25,23 +21,16 @@ function containsChatReviveWithPossibleMarkdown(message: Message): boolean {
   return !!message.content.match(chatReviveWithPossibleMD);
 }
 
-const cooldown = new CooldownManager({
-  type: "user",
-  defaultSeconds: 600,
-  overrides: new Map([[config.CXTIE_UID, 0]]),
-});
-
 const chatReviveSpec: ListenerSpec<Events.MessageCreate>
   = new MessageListenerBuilder()
     .setId("chat-revive")
     .filter(containsChatReviveWithPossibleMarkdown)
     .execute(replyWithNo)
-    // TODO: We might as well make saveCooldown (and maybe rename to
-    // useCooldown) automatically handle .filter(useCooldown(cooldown)) behind
-    // the scenes for us. Having to specify both .filter() and .saveCooldown()
-    // is redundant.
-    .filter(useCooldown(cooldown))
-    .saveCooldown(cooldown)
+    .cooldown({
+      type: "user",
+      defaultSeconds: 600,
+      overrides: new Map([[config.CXTIE_UID, 0]]),
+    })
     .toSpec();
 
 export default chatReviveSpec;

--- a/src/controllers/users/cxtie/no-x-no.listener.ts
+++ b/src/controllers/users/cxtie/no-x-no.listener.ts
@@ -1,8 +1,4 @@
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   channelPollutionAllowed,
   contentMatching,
 } from "../../../middleware/filters.middleware";
@@ -17,14 +13,10 @@ noXNo.execute(async (message) => {
   const { displayName } = message.author;
   await replySilently(message, `no ${displayName} no`);
 });
-
-const cooldown = new CooldownManager({
+noXNo.cooldown({
   type: "user",
   defaultSeconds: 60,
 });
-
-noXNo.filter(useCooldown(cooldown));
-noXNo.saveCooldown(cooldown);
 
 const noXNoSpec = noXNo.toSpec();
 export default noXNoSpec;

--- a/src/controllers/users/cxtie/sniffs.listener.ts
+++ b/src/controllers/users/cxtie/sniffs.listener.ts
@@ -1,9 +1,5 @@
 import config from "../../../config";
 import getLogger from "../../../logger";
-import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
 import { messageFrom } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import {
@@ -56,11 +52,7 @@ onSniffs.execute(async (message) => {
   }
   return true;
 });
-
-const cooldown = new CooldownManager({ type: "global", seconds: 300 });
-
-onSniffs.filter(useCooldown(cooldown));
-onSniffs.saveCooldown(cooldown);
+onSniffs.cooldown({ type: "global", seconds: 300 });
 
 const onSniffsSpec = onSniffs.toSpec();
 export default onSniffsSpec;

--- a/src/controllers/users/cxtie/tempy-wempy.listener.ts
+++ b/src/controllers/users/cxtie/tempy-wempy.listener.ts
@@ -2,10 +2,6 @@ import { GuildTextBasedChannel } from "discord.js";
 
 import getLogger from "../../../logger";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   contentMatching,
   isPollutionImmuneChannel,
 } from "../../../middleware/filters.middleware";
@@ -37,10 +33,7 @@ onTempyWempy.execute(async (message) => {
     `(${reacted ? "reacted" : "replied"}).`,
   );
 });
-
-const cooldown = new CooldownManager({ type: "global", seconds: 60 });
-onTempyWempy.filter(useCooldown(cooldown));
-onTempyWempy.saveCooldown(cooldown);
+onTempyWempy.cooldown({ type: "global", seconds: 60 });
 
 const onTempyWempySpec = onTempyWempy.toSpec();
 export default onTempyWempySpec;

--- a/src/controllers/users/deez/deez.listener.ts
+++ b/src/controllers/users/deez/deez.listener.ts
@@ -1,10 +1,5 @@
-import { Events, Message } from "discord.js";
+import { Events } from "discord.js";
 
-import getLogger from "../../../logger";
-import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
 import {
   channelPollutionAllowed,
   contentMatching,
@@ -13,26 +8,15 @@ import {
   ListenerSpec,
   MessageListenerBuilder,
 } from "../../../types/listener.types";
-import { replySilently } from "../../../utils/interaction.utils";
-import { formatContext } from "../../../utils/logging.utils";
-
-const log = getLogger(__filename);
-
-async function execute(message: Message) {
-  await replySilently(message, "deez");
-  log.debug(`${formatContext(message)}: replied with deez.`);
-}
-
-const cooldown = new CooldownManager({ type: "global", seconds: 600 });
+import { echoContent } from "../../../utils/interaction.utils";
 
 const deezSpec: ListenerSpec<Events.MessageCreate>
   = new MessageListenerBuilder()
     .setId("deez")
     .filter(channelPollutionAllowed)
-    .filter(contentMatching(/^deez$/i))
-    .execute(execute)
-    .filter(useCooldown(cooldown))
-    .saveCooldown(cooldown)
+    .filter(contentMatching(/^dee+z$/i))
+    .execute(echoContent)
+    .cooldown({ type: "global", seconds: 600 })
     .toSpec();
 
 export default deezSpec;

--- a/src/controllers/users/klee/dab.listener.ts
+++ b/src/controllers/users/klee/dab.listener.ts
@@ -1,10 +1,6 @@
 import config from "../../../config";
 import getLogger from "../../../logger";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   channelPollutionAllowedOrBypass,
   contentMatching,
   ignoreBots,
@@ -30,7 +26,7 @@ onDab.execute(async (message) => {
   log.debug(`${formatContext(message)}: dabbed back.`);
 });
 
-const cooldown = new CooldownManager({
+onDab.cooldown({
   type: "global",
   seconds: 600,
   bypassers: [config.KLEE_UID],
@@ -38,9 +34,6 @@ const cooldown = new CooldownManager({
     await message.react(GUILD_EMOJIS.NEKO_L);
   },
 });
-
-onDab.filter(useCooldown(cooldown));
-onDab.saveCooldown(cooldown);
 
 const onDabSpec = onDab.toSpec();
 export default onDabSpec;

--- a/src/controllers/users/misc/gulp.listener.ts
+++ b/src/controllers/users/misc/gulp.listener.ts
@@ -1,9 +1,5 @@
 import config from "../../../config";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   contentMatching,
   messageFrom,
 } from "../../../middleware/filters.middleware";
@@ -15,10 +11,7 @@ const onGulp = new MessageListenerBuilder().setId("gulp");
 onGulp.filter(messageFrom(config.BUNNY_UID));
 onGulp.filter(contentMatching(/^gulp$/i));
 onGulp.execute(replySilentlyWith("gulp"));
-
-const cooldown = new CooldownManager({ type: "global", seconds: 600 });
-onGulp.filter(useCooldown(cooldown));
-onGulp.saveCooldown(cooldown);
+onGulp.cooldown({ type: "global", seconds: 600 });
 
 const onGulpSpec = onGulp.toSpec();
 export default onGulpSpec;

--- a/src/controllers/users/misc/mwah.listener.ts
+++ b/src/controllers/users/misc/mwah.listener.ts
@@ -1,9 +1,5 @@
 import config from "../../../config";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   contentMatching,
   messageFrom,
 } from "../../../middleware/filters.middleware";
@@ -15,10 +11,7 @@ const onMwah = new MessageListenerBuilder().setId("mwah");
 onMwah.filter(messageFrom(config.J_UID));
 onMwah.filter(contentMatching(/^mwah$/i));
 onMwah.execute(replySilentlyWith("mwah"));
-
-const cooldown = new CooldownManager({ type: "global", seconds: 600 });
-onMwah.filter(useCooldown(cooldown));
-onMwah.saveCooldown(cooldown);
+onMwah.cooldown({ type: "global", seconds: 600 });
 
 const onMwahSpec = onMwah.toSpec();
 export default onMwahSpec;

--- a/src/controllers/users/ni/popipo.listener.ts
+++ b/src/controllers/users/ni/popipo.listener.ts
@@ -1,10 +1,6 @@
 import config from "../../../config";
 import getLogger from "../../../logger";
 import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
-import {
   channelPollutionAllowedOrBypass,
   contentMatching,
 } from "../../../middleware/filters.middleware";
@@ -27,14 +23,11 @@ onPopipo.execute(async (message) => {
   log.debug(`${formatContext(message)}: replied with '${response}'.`);
 });
 
-const cooldown = new CooldownManager({
+onPopipo.cooldown({
   type: "user",
   defaultSeconds: 60,
   overrides: new Map([[config.NI_UID, 0]]),
 });
-
-onPopipo.filter(useCooldown(cooldown));
-onPopipo.saveCooldown(cooldown);
 
 const onPopipoSpec = onPopipo.toSpec();
 export default onPopipoSpec;

--- a/src/controllers/users/s/hello-world.listener.ts
+++ b/src/controllers/users/s/hello-world.listener.ts
@@ -1,18 +1,17 @@
-import { MessageFlags } from "discord.js";
+import { MessageFlags, userMention } from "discord.js";
 import config from "../../../config";
 import {
   contentMatching,
   messageFrom,
 } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
-import { toUserMention } from "../../../utils/markdown.utils";
 
 const helloWorld = new MessageListenerBuilder().setId("hello-world");
 
 helloWorld.filter(messageFrom(config.S_UID));
 helloWorld.filter(contentMatching(/^(# )?hello world[.~!?-]*$/i));
 helloWorld.execute(async (message) => {
-  const tacoMention = toUserMention(config.TACO_UID);
+  const tacoMention = userMention(config.TACO_UID);
   await message.reply({
     content: tacoMention,
     allowedMentions: {

--- a/src/controllers/users/wav/pookie.listener.ts
+++ b/src/controllers/users/wav/pookie.listener.ts
@@ -1,9 +1,5 @@
 import config from "../../../config";
 import getLogger from "../../../logger";
-import {
-  CooldownManager,
-  useCooldown,
-} from "../../../middleware/cooldown.middleware";
 import { contentMatching } from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
@@ -13,13 +9,12 @@ const log = getLogger(__filename);
 
 const onPookie = new MessageListenerBuilder().setId("pookie");
 
-onPookie.filter(contentMatching(/^pookie$/i));
+onPookie.filter(contentMatching(/^pookie+$/i));
 onPookie.execute(async (message) => {
   await message.react(GUILD_EMOJIS.NEKO_UWU);
-  log.debug(`${formatContext(message)}: reacted to pookie.`);
+  log.debug(`${formatContext(message)}: reacted to '${message.content}'.`);
 });
-
-const cooldown = new CooldownManager({
+onPookie.cooldown({
   type: "user",
   defaultSeconds: 300,
   overrides: new Map([
@@ -27,9 +22,6 @@ const cooldown = new CooldownManager({
     [config.COFFEE_UID, 0],
   ]),
 });
-
-onPookie.filter(useCooldown(cooldown));
-onPookie.saveCooldown(cooldown);
 
 const onPookieSpec = onPookie.toSpec();
 export default onPookieSpec;

--- a/src/middleware/cooldown.middleware.ts
+++ b/src/middleware/cooldown.middleware.ts
@@ -427,6 +427,10 @@ export function useCooldown(
 /**
  * Add a cooldown mechanism to this event listener. This filter passes only if
  * cooldown isn't currently active.
+ *
+ * NOTE: If adding this middleware to a message creation listener, it might be
+ * better to use its custom `.cooldown()` method as that also saves the cooldown
+ * manager instance such that it can be dynamically updated at runtime later.
  */
 export function useCooldown(
   value: CooldownManager | CooldownSpec,

--- a/src/middleware/privilege.middleware.ts
+++ b/src/middleware/privilege.middleware.ts
@@ -1,11 +1,10 @@
-import { CommandInteraction, GuildMember } from "discord.js";
+import { CommandInteraction, GuildMember, roleMention } from "discord.js";
 
 import config from "../config";
 import getLogger from "../logger";
 import { CommandCheck } from "../types/command.types";
 import { iterateEnum } from "../utils/iteration.utils";
 import { formatContext } from "../utils/logging.utils";
-import { toRoleMention } from "../utils/markdown.utils";
 
 const log = getLogger(__filename);
 
@@ -65,10 +64,10 @@ export function checkPrivilege(commandLevel: RoleLevel): CommandCheck {
       throw new Error("commandLevel was NONE, check shouldn't have failed.");
     }
     const minimumRoleId = LEVEL_TO_RID[commandLevel];
-    const roleMention = toRoleMention(minimumRoleId);
+    const mention = roleMention(minimumRoleId);
     const reason = (
       "minimum required privilege level: " +
-      `\`${RoleLevel[commandLevel]}\` (${roleMention})`
+      `\`${RoleLevel[commandLevel]}\` (${mention})`
     );
     const response = (
       `**${member.user.username}**, you're not allowed to use this command!` +

--- a/src/services/luke.service.ts
+++ b/src/services/luke.service.ts
@@ -28,25 +28,28 @@ export class LukeService {
     const [, notPresent, captured] = matches;
 
     let response: string;
+    let jokeType: "negative" | "affirmative" | "welcome";
 
     // Negative version of the joke.
     if (notPresent) {
       response =
         `Of course you're not ${captured}, you're ${author.displayName}!`;
+      jokeType = "negative";
     }
 
     // Affirmative version of the joke.
-    else if (captured.match(/^(back|awake|up|here)[.~!?-]*$/i)) {
+    else if (captured.match(/^(back|awake|up|here|alive)[.~!?-]*$/i)) {
       response = `Welcome back, ${author.displayName}!`;
+      jokeType = "welcome";
     }
     else {
       response = `Hi ${captured}, I'm ${message.client.user.displayName}!`;
+      jokeType = "affirmative";
     }
 
     await replySilently(message, response);
     log.debug(
-      `${formatContext(message)}: replied with Dad joke ` +
-      `(${notPresent ? "negative" : "affirmative"} version).`,
+      `${formatContext(message)}: replied with Dad joke (${jokeType} version).`,
     );
     return true;
   };

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -186,19 +186,6 @@ export class MessageListenerBuilder
 
   constructor() { super(Events.MessageCreate); }
 
-  /**
-   * @deprecated Use `.cooldown()` instead.
-   *
-   * Save the dynamic cooldown manager for message creation listeners. If you
-   * want to be able to change this listener's cooldown spec at runtime (such as
-   * through commands), then you should include this call in addition to the
-   * middleware passed to the filters.
-   */
-  public saveCooldown(manager: CooldownManager): this {
-    this.cooldownManager = manager;
-    return this;
-  }
-
   public cooldown(manager: CooldownManager): this;
   public cooldown(spec: CooldownSpec): this;
   /**

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -41,3 +41,12 @@ export function reactWith(emoji: EmojiResolvable)
     log.debug(`${formatContext(message)}: reacted with ${emoji}.`);
   };
 }
+
+/**
+ * Silently reply to the message with the message's own content.
+ */
+export const echoContent: ListenerExecuteFunction<Events.MessageCreate>
+  = async function (message) {
+    await replySilently(message, message.content);
+    log.debug(`${formatContext(message)}: echoed '${message.content}'.`);
+  };

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -1,7 +1,12 @@
 // Also see:
 // https://v13.discordjs.guide/miscellaneous/parsing-mention-arguments.html
 
-import { userMention } from "discord.js";
+import {
+  TimestampStyles,
+  TimestampStylesString,
+  userMention,
+} from "discord.js";
+
 import { toUnixSeconds } from "./dates.utils";
 
 export type Mentionable = {
@@ -55,43 +60,29 @@ export function joinUserMentions(userIds?: Iterable<string>): string {
   return Array.from(userIds).map(userMention).join(", ");
 }
 
-/**
- * See: https://gist.github.com/LeviSnoot/d9147767abeef2f770e9ddcd91eb85aa.
- */
-export enum TimestampFormat {
-  /** 12-hour Example: 9:01 AM */
-  SHORT_TIME = "t",
-  /** 12-hour Example: 9:01:00 AM */
-  LONG_TIME = "T",
-  /** 12-hour Example: 11/28/2018 */
-  SHORT_DATE = "d",
-  /** 12-hour Example: November 28, 2018 */
-  LONG_DATE = "D",
-  /** 12-hour Example: November 28, 2018 9:01 AM */
-  SHORT_DATETIME = "f",
-  /** 12-hour Example: Wednesday, November 28, 2018 9:01 AM */
-  LONG_DATETIME = "F",
-  /** 12-hour Example: 3 years ago */
-  RELATIVE = "R",
-}
+export type TimestampMention<F extends TimestampStylesString | null = null>
+  = F extends null ? `<t:${number}>` : `<t:${number}:${F}>`;
 
+export function toTimestampMention(date: Date): `<t:${number}>`;
+export function toTimestampMention<F extends TimestampStylesString>(
+  date: Date,
+  format: F,
+): TimestampMention<F>;
 export function toTimestampMention(
   date: Date,
-  format?: TimestampFormat,
-): string {
+  format?: TimestampStylesString,
+): TimestampMention<any> {
   const unixTimestamp = toUnixSeconds(date);
-  let result = `<t:${unixTimestamp}`;
   if (format) {
-    result += `:${format}`;
+    return `<t:${unixTimestamp}:${format}>`;
   }
-  result += ">";
-  return result;
+  return `<t:${unixTimestamp}>`;
 }
 
-export function toRelativeTimestampMention(date: Date): string {
+export function toRelativeTimestampMention(date: Date): TimestampMention<"R"> {
   // I assume this format is among the most common ones besides the default one,
   // so it's nice to have a shorthand function partial.
-  return toTimestampMention(date, TimestampFormat.RELATIVE);
+  return toTimestampMention(date, TimestampStyles.RelativeTime);
 }
 
 export function toBulletedList(lines: string[], level: number = 0): string {

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -3,14 +3,23 @@
 
 import { toUnixSeconds } from "./dates.utils";
 
+/**
+ * @deprecated discord.js already provides this utility via `roleMention()`.
+ */
 export function toRoleMention(roleId: string): string {
   return `<@&${roleId}>`;
 }
 
+/**
+ * @deprecated discord.js already provides this utility via `userMention()`.
+ */
 export function toUserMention(userId: string): string {
   return `<@${userId}>`;
 }
 
+/**
+ * @deprecated discord.js already provides this utility via `channelMention()`.
+ */
 export function toChannelMention(channelId: string): string {
   return `<#${channelId}>`;
 }

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -1,13 +1,7 @@
 // Also see:
 // https://v13.discordjs.guide/miscellaneous/parsing-mention-arguments.html
 
-import {
-  TimestampStyles,
-  TimestampStylesString,
-  userMention,
-} from "discord.js";
-
-import { toUnixSeconds } from "./dates.utils";
+import { TimestampStylesString, userMention } from "discord.js";
 
 export type Mentionable = {
   type: "user";
@@ -62,28 +56,6 @@ export function joinUserMentions(userIds?: Iterable<string>): string {
 
 export type TimestampMention<F extends TimestampStylesString | null = null>
   = F extends null ? `<t:${number}>` : `<t:${number}:${F}>`;
-
-export function toTimestampMention(date: Date): `<t:${number}>`;
-export function toTimestampMention<F extends TimestampStylesString>(
-  date: Date,
-  format: F,
-): TimestampMention<F>;
-export function toTimestampMention(
-  date: Date,
-  format?: TimestampStylesString,
-): TimestampMention<any> {
-  const unixTimestamp = toUnixSeconds(date);
-  if (format) {
-    return `<t:${unixTimestamp}:${format}>`;
-  }
-  return `<t:${unixTimestamp}>`;
-}
-
-export function toRelativeTimestampMention(date: Date): TimestampMention<"R"> {
-  // I assume this format is among the most common ones besides the default one,
-  // so it's nice to have a shorthand function partial.
-  return toTimestampMention(date, TimestampStyles.RelativeTime);
-}
 
 export function toBulletedList(lines: string[], level: number = 0): string {
   const indent = "  ".repeat(level);

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -1,28 +1,8 @@
 // Also see:
 // https://v13.discordjs.guide/miscellaneous/parsing-mention-arguments.html
 
+import { userMention } from "discord.js";
 import { toUnixSeconds } from "./dates.utils";
-
-/**
- * @deprecated discord.js already provides this utility via `roleMention()`.
- */
-export function toRoleMention(roleId: string): string {
-  return `<@&${roleId}>`;
-}
-
-/**
- * @deprecated discord.js already provides this utility via `userMention()`.
- */
-export function toUserMention(userId: string): string {
-  return `<@${userId}>`;
-}
-
-/**
- * @deprecated discord.js already provides this utility via `channelMention()`.
- */
-export function toChannelMention(channelId: string): string {
-  return `<#${channelId}>`;
-}
 
 export type Mentionable = {
   type: "user";
@@ -72,7 +52,7 @@ export function parseMention(mention: string): Mentionable | null {
 
 export function joinUserMentions(userIds?: Iterable<string>): string {
   if (!userIds) return "";
-  return Array.from(userIds).map(toUserMention).join(", ");
+  return Array.from(userIds).map(userMention).join(", ");
 }
 
 /**

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -15,6 +15,52 @@ export function toChannelMention(channelId: string): string {
   return `<#${channelId}>`;
 }
 
+export type Mentionable = {
+  type: "user";
+  uid: string;
+} | {
+  type: "role";
+  rid: string;
+} | {
+  type: "channel";
+  cid: string;
+};
+
+export function parseMention(mention: string): Mentionable | null {
+  function isIntegerString(s: string): boolean {
+    // Edge case: Number("") == 0, so don't let that case fall through.
+    if (!s) return false;
+    const num = Number(s);
+    return Number.isInteger(num);
+  }
+
+  if (!mention.endsWith(">")) return null;
+
+  if (mention.startsWith("<#")) {
+    const cid = mention.slice(2, -1);
+    if (!isIntegerString(cid)) return null;
+    return { type: "channel", cid };
+  }
+
+  if (mention.startsWith("<@&")) {
+    const rid = mention.slice(3, -1);
+    if (!isIntegerString(rid)) return null;
+    return { type: "role", rid };
+  }
+
+  if (mention.startsWith("<@")) {
+    let uid = mention.slice(2, -1);
+    // If the user has a nickname, the mention looks like <@!UID>.
+    if (uid.startsWith("!")) {
+      uid = uid.slice(1);
+    }
+    if (!isIntegerString(uid)) return null;
+    return { type: "user", uid };
+  }
+
+  return null;
+}
+
 export function joinUserMentions(userIds?: Iterable<string>): string {
   if (!userIds) return "";
   return Array.from(userIds).map(toUserMention).join(", ");

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -1,8 +1,6 @@
+import { TimestampStyles, time } from "discord.js";
+
 import pingSpec from "../../../src/controllers/dev/ping.command";
-import {
-  toRelativeTimestampMention,
-  toTimestampMention,
-} from "../../../src/utils/markdown.utils";
 import { MockInteraction, TestClient, addMockGetter } from "../../test-utils";
 
 describe("/ping command", () => {
@@ -24,12 +22,12 @@ describe("/ping command", () => {
 
     await mock.simulateCommand();
 
-    const timestamp = toTimestampMention(dummyReadySince);
-    const relativeTimestamp = toRelativeTimestampMention(dummyReadySince);
+    const timestamp = time(dummyReadySince);
+    const relativeTime = time(dummyReadySince, TimestampStyles.RelativeTime);
     const expectedParts = [
       `Latency: **${dummyPing}**`,
       `Branch: \`${dummyBranchName}\``,
-      `Ready: ${timestamp} (${relativeTimestamp})`,
+      `Ready: ${timestamp} (${relativeTime})`,
     ];
     for (const part of expectedParts) {
       mock.expectRepliedWith({

--- a/tests/controllers/users/coffee/uff.listener.test.ts
+++ b/tests/controllers/users/coffee/uff.listener.test.ts
@@ -2,16 +2,23 @@ import config from "../../../../src/config";
 import uffSpec from "../../../../src/controllers/users/coffee/uff.listener";
 import { MockMessage } from "../../../test-utils";
 
+let mock: MockMessage;
+beforeEach(() => { mock = new MockMessage(uffSpec); });
+
 it("should bark in response to uff if from coffee", async () => {
-  const mock = new MockMessage(uffSpec)
-    .mockAuthor({ uid: config.COFFEE_UID })
-    .mockContent("uff");
+  mock.mockAuthor({ uid: config.COFFEE_UID }).mockContent("uff");
   await mock.simulateEvent();
-  mock.expectRepliedSilentlyWith({ content: "woof" });
+  mock.expectRepliedSilentlyWith("woof");
 });
 
 it("should do nothing if the sender isn't coffee", async () => {
-  const mock = new MockMessage(uffSpec).mockContent("uff");
+  mock.mockContent("uff");
   await mock.simulateEvent();
   mock.expectNotResponded();
+});
+
+it("should trigger even on extended uff", async () => {
+  mock.mockAuthor({ uid: config.COFFEE_UID }).mockContent("ufffffffffff");
+  await mock.simulateEvent();
+  mock.expectRepliedSilentlyWith("woof");
 });

--- a/tests/controllers/users/coffee/uwu.listener.test.ts
+++ b/tests/controllers/users/coffee/uwu.listener.test.ts
@@ -1,8 +1,23 @@
 import uwuSpec from "../../../../src/controllers/users/coffee/uwu.listener";
 import { MockMessage } from "../../../test-utils";
 
+let mock: MockMessage;
+beforeEach(() => { mock = new MockMessage(uwuSpec); });
+
 it("should react with vomit", async () => {
-  const mock = new MockMessage(uwuSpec).mockContent("uwu");
+  mock.mockContent("uwu");
+  await mock.simulateEvent();
+  mock.expectReactedWith("🤢", "🤮");
+});
+
+it("should do nothing if conditions not met", async () => {
+  mock.mockContent("general kenobi!");
+  await mock.simulateEvent();
+  mock.expectNotResponded();
+});
+
+it("should trigger even on extended uwu", async () => {
+  mock.mockContent("uwuuuuuuuuuuuuuu");
   await mock.simulateEvent();
   mock.expectReactedWith("🤢", "🤮");
 });

--- a/tests/controllers/users/cxtie/rizz.listener.test.ts
+++ b/tests/controllers/users/cxtie/rizz.listener.test.ts
@@ -12,7 +12,7 @@ describe("rizz listener", () => {
   it("should react if content contains cringe emojis", async () => {
     const sup: CustomEmoji = { id: SUP_EMOJI_ID, name: "sup" };
     const mock = new MockMessage(onRizzSpec)
-      .mockAuthorId(config.CXTIE_UID!)
+      .mockAuthor({ uid: config.CXTIE_UID })
       .mockContent(toEscapedEmoji(sup));
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_GUN);
@@ -20,7 +20,7 @@ describe("rizz listener", () => {
 
   it("should react if content is 'tucks hair'", async () => {
     const mock = new MockMessage(onRizzSpec)
-      .mockAuthorId(config.CXTIE_UID!)
+      .mockAuthor({ uid: config.CXTIE_UID })
       .mockContent("*tucks hair*");
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_GUN);

--- a/tests/controllers/users/deez/deez.listener.test.ts
+++ b/tests/controllers/users/deez/deez.listener.test.ts
@@ -2,18 +2,24 @@ import deezSpec from "../../../../src/controllers/users/deez/deez.listener";
 
 import { MockMessage } from "../../../test-utils";
 
-describe("deez listener", () => {
-  it("should not respond if the content isn't deez", async () => {
-    const mock = new MockMessage(deezSpec);
-    mock.mockContent("lorem ipsum");
-    await mock.simulateEvent();
-    mock.expectNotResponded();
-  });
+let mock: MockMessage;
+beforeEach(() => { mock = new MockMessage(deezSpec); });
 
-  it("should reply silently with deez if the content is deez", async () => {
-    const mock = new MockMessage(deezSpec);
-    mock.mockContent("deez");
-    await mock.simulateEvent();
-    mock.expectRepliedSilentlyWith({ content: "deez" });
-  });
+it("should not respond if the content isn't deez", async () => {
+  mock.mockContent("lorem ipsum");
+  await mock.simulateEvent();
+  mock.expectNotResponded();
+});
+
+it("should reply silently with deez if the content is deez", async () => {
+  mock.mockContent("deez");
+  await mock.simulateEvent();
+  mock.expectRepliedSilentlyWith("deez");
+});
+
+it("should trigger on and echo extended deez", async () => {
+  const extendedDeez = "deeeeeeeeeez";
+  mock.mockContent(extendedDeez);
+  await mock.simulateEvent();
+  mock.expectRepliedSilentlyWith(extendedDeez);
 });

--- a/tests/controllers/users/klee/dab.listener.test.ts
+++ b/tests/controllers/users/klee/dab.listener.test.ts
@@ -9,26 +9,26 @@ describe("dab listener", () => {
   });
 
   it("shouldn't respond if the content isn't dab", async () => {
-    mock.mockContent("lorem ipsum").mockAuthorBot(false);
+    mock.mockContent("lorem ipsum");
     await mock.simulateEvent();
     mock.expectNotResponded();
   });
 
   it("should respond with dab if the content is dab", async () => {
-    mock.mockContent("dab").mockAuthorBot(false);
+    mock.mockContent("dab");
     await mock.simulateEvent();
     mock.expectRepliedSilentlyWith({ content: "dab" });
   });
 
   it("should react with neko L in pollution-immune channel", async () => {
     addMockGetter(mock.message, "channel", { name: "general" });
-    mock.mockContent("dab").mockAuthorBot(false);
+    mock.mockContent("dab");
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_L);
   });
 
   it("should react with neko L if on cooldown", async () => {
-    mock.mockContent("dab").mockAuthorBot(false).mockCooldownActive();
+    mock.mockContent("dab").mockCooldownActive();
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_L);
   });

--- a/tests/controllers/users/s/hello-world.listener.test.ts
+++ b/tests/controllers/users/s/hello-world.listener.test.ts
@@ -1,8 +1,7 @@
-import { MessageFlags, MessageMentionOptions } from "discord.js";
+import { MessageFlags, MessageMentionOptions, userMention } from "discord.js";
 
 import config from "../../../../src/config";
 import helloWorldSpec from "../../../../src/controllers/users/s/hello-world.listener";
-import { toUserMention } from "../../../../src/utils/markdown.utils";
 import { MockMessage } from "../../../test-utils";
 
 it("should ping Taco when S sends hello world", async () => {
@@ -13,7 +12,7 @@ it("should ping Taco when S sends hello world", async () => {
   await mock.simulateEvent();
 
   mock.expectRepliedWith({
-    content: expect.stringContaining(toUserMention(config.TACO_UID)),
+    content: expect.stringContaining(userMention(config.TACO_UID)),
     allowedMentions: expect.objectContaining<MessageMentionOptions>({
       repliedUser: false,
       users: expect.arrayContaining([config.TACO_UID]),

--- a/tests/controllers/users/wav/pookie.listener.test.ts
+++ b/tests/controllers/users/wav/pookie.listener.test.ts
@@ -3,18 +3,23 @@ import onPookieSpec from "../../../../src/controllers/users/wav/pookie.listener"
 import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
 import { MockMessage } from "../../../test-utils";
 
-describe("pookie listener", () => {
-  it("should react with neko uwu if content is pookie", async () => {
-    const mock = new MockMessage(onPookieSpec);
-    mock.mockContent("pookie");
-    await mock.simulateEvent();
-    mock.expectReactedWith(GUILD_EMOJIS.NEKO_UWU);
-  });
+let mock: MockMessage;
+beforeEach(() => { mock = new MockMessage(onPookieSpec); });
 
-  it("shouldn't do anything if content isn't pookie", async () => {
-    const mock = new MockMessage(onPookieSpec);
-    mock.mockContent("lorem ipsum");
-    await mock.simulateEvent();
-    mock.expectNotResponded();
-  });
+it("should react with neko uwu if content is pookie", async () => {
+  mock.mockContent("pookie");
+  await mock.simulateEvent();
+  mock.expectReactedWith(GUILD_EMOJIS.NEKO_UWU);
+});
+
+it("shouldn't do anything if content isn't pookie", async () => {
+  mock.mockContent("lorem ipsum");
+  await mock.simulateEvent();
+  mock.expectNotResponded();
+});
+
+it("should trigger even on extended pookie", async () => {
+  mock.mockContent("pookieeeeeee");
+  await mock.simulateEvent();
+  mock.expectReactedWith(GUILD_EMOJIS.NEKO_UWU);
 });

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -257,14 +257,6 @@ export class MockMessage {
   /**
    * @deprecated Use the more general `mockAuthor` method instead.
    */
-  public mockAuthorBot(isBot: boolean): this {
-    this.message.author.bot = isBot;
-    return this;
-  }
-
-  /**
-   * @deprecated Use the more general `mockAuthor` method instead.
-   */
   public mockAuthorId(uid: string): this {
     this.message.author.id = uid;
     return this;

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -255,14 +255,6 @@ export class MockMessage {
   }
 
   /**
-   * @deprecated Use the more general `mockAuthor` method instead.
-   */
-  public mockAuthorId(uid: string): this {
-    this.message.author.id = uid;
-    return this;
-  }
-
-  /**
    * ARRANGE.
    *
    * Mock the message's author attached to the underlying message object.

--- a/tests/utils/interaction.utils.test.ts
+++ b/tests/utils/interaction.utils.test.ts
@@ -2,6 +2,7 @@ jest.mock("../../src/utils/logging.utils");
 
 import { Message, MessageFlags, MessageReplyOptions } from "discord.js";
 import {
+  echoContent,
   replySilently,
   replySilentlyWith,
 } from "../../src/utils/interaction.utils";
@@ -38,6 +39,23 @@ describe("replying silently (as a callback)", () => {
 
     expect(mockMessage.reply).toHaveBeenCalledWith(
       expect.objectContaining<MessageReplyOptions>({
+        allowedMentions: expect.objectContaining({ parse: [] }),
+        flags: MessageFlags.SuppressNotifications,
+      }),
+    );
+  });
+});
+
+describe("echoing a message's content", () => {
+  it("should echo the message's content", async () => {
+    const mockMessageWithContent = {
+      ...mockMessage,
+      content: "hello there",
+    } as Message;
+    await echoContent(mockMessageWithContent);
+    expect(mockMessageWithContent.reply).toHaveBeenCalledWith(
+      expect.objectContaining<MessageReplyOptions>({
+        content: "hello there",
         allowedMentions: expect.objectContaining({ parse: [] }),
         flags: MessageFlags.SuppressNotifications,
       }),

--- a/tests/utils/markdown.utils.test.ts
+++ b/tests/utils/markdown.utils.test.ts
@@ -1,14 +1,11 @@
 jest.mock("../../src/utils/dates.utils");
 
-import { TimestampStyles } from "discord.js";
 import { toUnixSeconds } from "../../src/utils/dates.utils";
 import {
   Mentionable,
   joinUserMentions,
   parseMention,
   toBulletedList,
-  toRelativeTimestampMention,
-  toTimestampMention,
 } from "../../src/utils/markdown.utils";
 
 const mockedToUnixSeconds = jest.mocked(toUnixSeconds);
@@ -19,25 +16,6 @@ describe("Discord object mention helpers", () => {
   it("should join user mentions", () => {
     const result = joinUserMentions(["123", "456", "789"]);
     expect(result).toEqual("<@123>, <@456>, <@789>");
-  });
-});
-
-describe("Discord timestamp helpers", () => {
-  it("should use the correct timestamp if format is omitted", () => {
-    const result = toTimestampMention(new Date());
-    expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}>`);
-  });
-
-  it("should use the correct timestamp format if specified", () => {
-    for (const formatCode of Object.values(TimestampStyles)) {
-      const result = toTimestampMention(new Date(), formatCode);
-      expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}:${formatCode}>`);
-    }
-  });
-
-  it("should use the relative timestamp format", () => {
-    const result = toRelativeTimestampMention(new Date());
-    expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}:R>`);
   });
 });
 

--- a/tests/utils/markdown.utils.test.ts
+++ b/tests/utils/markdown.utils.test.ts
@@ -7,11 +7,8 @@ import {
   joinUserMentions,
   parseMention,
   toBulletedList,
-  toChannelMention,
   toRelativeTimestampMention,
-  toRoleMention,
   toTimestampMention,
-  toUserMention,
 } from "../../src/utils/markdown.utils";
 
 const mockedToUnixSeconds = jest.mocked(toUnixSeconds);
@@ -19,21 +16,6 @@ const DUMMY_UNIX_TIME = 4242424242;
 mockedToUnixSeconds.mockReturnValue(DUMMY_UNIX_TIME);
 
 describe("Discord object mention helpers", () => {
-  it("should return a correct role mention", () => {
-    const result = toRoleMention("12345");
-    expect(result).toEqual("<@&12345>");
-  });
-
-  it("should return a correct user mention", () => {
-    const result = toUserMention("12345");
-    expect(result).toEqual("<@12345>");
-  });
-
-  it("should return a correct channel mention", () => {
-    const result = toChannelMention("12345");
-    expect(result).toEqual("<#12345>");
-  });
-
   it("should join user mentions", () => {
     const result = joinUserMentions(["123", "456", "789"]);
     expect(result).toEqual("<@123>, <@456>, <@789>");

--- a/tests/utils/markdown.utils.test.ts
+++ b/tests/utils/markdown.utils.test.ts
@@ -1,9 +1,9 @@
 jest.mock("../../src/utils/dates.utils");
 
+import { TimestampStyles } from "discord.js";
 import { toUnixSeconds } from "../../src/utils/dates.utils";
 import {
   Mentionable,
-  TimestampFormat,
   joinUserMentions,
   parseMention,
   toBulletedList,
@@ -29,7 +29,7 @@ describe("Discord timestamp helpers", () => {
   });
 
   it("should use the correct timestamp format if specified", () => {
-    for (const formatCode of Object.values(TimestampFormat)) {
+    for (const formatCode of Object.values(TimestampStyles)) {
       const result = toTimestampMention(new Date(), formatCode);
       expect(result).toEqual(`<t:${DUMMY_UNIX_TIME}:${formatCode}>`);
     }


### PR DESCRIPTION
Various refactors, notably:

* Removed custom utility functions for formatting mentions since the discord.js library already provides helper functions for them.
* Added a `parseMention` helper... which I think might also be close to obsolete since discord.js also provides [regex patterns](https://v13.discordjs.guide/miscellaneous/parsing-mention-arguments.html#using-regular-expressions) that help parse mentions and extract IDs.
* Finished phasing out all `@deprecated` methods, including the `.saveCooldown()` from before #54 and the `.mockAuthorId()`, `.mockAuthorBot()` methods on `MockMessage` from before the generalized `.mockAuthor()` was introduced.

Various feature enhancements:

* `deez` now triggers on 2+ number of e's in deez e.g. `deeeeeez`.
* `uff`, `uwu`, and `pookie` all can now trigger even then the last character is dragged out e.g. `uwuuuuuuu`.
* Added "i'm alive" case to trigger the "Welcome back" version of the Dad joke.