### PR TITLE
Tweak uwu listener

### DIFF
--- a/src/controllers/users/coffee/uwu.listener.ts
+++ b/src/controllers/users/coffee/uwu.listener.ts
@@ -7,21 +7,36 @@ import {
   ListenerSpec,
   MessageListenerBuilder,
 } from "../../../types/listener.types";
+import { GUILD_EMOJIS } from "../../../utils/emojis.utils";
 import { formatContext } from "../../../utils/logging.utils";
 
 const log = getLogger(__filename);
 
-async function reactWithVomit(message: Message) {
+async function reactWithVomit(message: Message): Promise<void> {
   await message.react("🤢");
   await message.react("🤮");
-  log.debug(`${formatContext(message)}: reacted to uwu.`);
+  log.debug(`${formatContext(message)}: reacted with vomit to uwu.`);
+}
+
+async function reactWithKofi(message: Message): Promise<void> {
+  await message.react(GUILD_EMOJIS.KOFI);
+  log.debug(`${formatContext(message)}: reacted with kofi to uwu.`);
+}
+
+async function reactBasedOnAuthor(message: Message): Promise<void> {
+  if (message.author.id === config.COFFEE_UID) {
+    await reactWithKofi(message);
+  }
+  else {
+    await reactWithVomit(message);
+  }
 }
 
 const uwuSpec: ListenerSpec<Events.MessageCreate>
   = new MessageListenerBuilder()
     .setId("uwu")
     .filter(contentMatching(/^uwu+$/i))
-    .execute(reactWithVomit)
+    .execute(reactBasedOnAuthor)
     .cooldown({
       type: "global",
       seconds: 10,

--- a/src/controllers/users/coffee/uwu.listener.ts
+++ b/src/controllers/users/coffee/uwu.listener.ts
@@ -35,7 +35,7 @@ async function reactBasedOnAuthor(message: Message): Promise<void> {
 const uwuSpec: ListenerSpec<Events.MessageCreate>
   = new MessageListenerBuilder()
     .setId("uwu")
-    .filter(contentMatching(/^uwu+$/i))
+    .filter(contentMatching(/\bu *(w *u)+u*\b/i))
     .execute(reactBasedOnAuthor)
     .cooldown({
       type: "global",

--- a/tests/controllers/users/coffee/uwu.listener.test.ts
+++ b/tests/controllers/users/coffee/uwu.listener.test.ts
@@ -29,3 +29,15 @@ it("should react with kofi if coffee says uwu", async () => {
   await mock.simulateEvent();
   mock.expectReactedWith(GUILD_EMOJIS.KOFI);
 });
+
+it("it should trigger on repeated wu", async () => {
+  mock.mockContent("uwuwuwuwu");
+  await mock.simulateEvent();
+  mock.expectReactedWith("🤢", "🤮");
+});
+
+it("should trigger on spaced uwu", async () => {
+  mock.mockContent("u   w   u");
+  await mock.simulateEvent();
+  mock.expectReactedWith("🤢", "🤮");
+});

--- a/tests/controllers/users/coffee/uwu.listener.test.ts
+++ b/tests/controllers/users/coffee/uwu.listener.test.ts
@@ -1,4 +1,6 @@
+import config from "../../../../src/config";
 import uwuSpec from "../../../../src/controllers/users/coffee/uwu.listener";
+import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
 import { MockMessage } from "../../../test-utils";
 
 let mock: MockMessage;
@@ -20,4 +22,10 @@ it("should trigger even on extended uwu", async () => {
   mock.mockContent("uwuuuuuuuuuuuuuu");
   await mock.simulateEvent();
   mock.expectReactedWith("🤢", "🤮");
+});
+
+it("should react with kofi if coffee says uwu", async () => {
+  mock.mockContent("uwu").mockAuthor({ uid: config.COFFEE_UID });
+  await mock.simulateEvent();
+  mock.expectReactedWith(GUILD_EMOJIS.KOFI);
 });


### PR DESCRIPTION
1. **Feature requested by Coffee:** 
![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/22731bb1-f83a-488f-ac98-51dd3a607fdd)

2. Expand uwu's regex to now trigger on words like "uwuwuwuwu" and "u w u". Also, the pattern need not be a full match (`^$`) but rather appear as "word" (`\b\b`).