### PR TITLE
Attempt to broadcast timeout even if DM fails

### DIFF
--- a/src/controllers/moderation/timeout-broadcast.listener.ts
+++ b/src/controllers/moderation/timeout-broadcast.listener.ts
@@ -128,16 +128,33 @@ timeoutBroadcast.execute(async (auditLogEntry, guild) => {
     flags: MessageFlags.SuppressNotifications,
   };
 
-  await dmChannel.send(payload);
-  log.debug(`DM'ed @${target.user.username} reason for timeout.`);
-  await broadcastChannel.send(payload);
-  log.debug(`broadcasted timeout in #${broadcastChannel.name}.`);
+  const username = target.user.username;
+  let failed: boolean = false;
+  try {
+    await dmChannel.send(payload);
+    log.debug(`DM'ed @${username} reason for timeout.`);
+  }
+  catch (error) {
+    log.error(`failed to DM @${username} timeout details.`);
+    console.error(error);
+    failed = true;
+  }
+  try {
+    await broadcastChannel.send(payload);
+    log.debug(`broadcasted timeout in #${broadcastChannel.name}.`);
+  }
+  catch (error) {
+    log.error(`failed to broadcast timeout details for @${username}`);
+    console.error(error);
+    failed = true;
+  }
+  if (failed) return false;
 
   if (details.type === "issued") {
-    log.info(`reported timeout issued for @${target.user.username}.`);
+    log.info(`reported timeout issued for @${username}.`);
   }
   else if (details.type === "removed") {
-    log.info(`reported timeout removed for @${target.user.username}.`);
+    log.info(`reported timeout removed for @${username}.`);
   }
   return true;
 });

--- a/src/controllers/moderation/timeout-broadcast.listener.ts
+++ b/src/controllers/moderation/timeout-broadcast.listener.ts
@@ -1,5 +1,6 @@
 import {
   AuditLogEvent,
+  DMChannel,
   EmbedBuilder,
   Events,
   Guild,
@@ -25,6 +26,10 @@ const log = getLogger(__filename);
 const timeoutBroadcast = new ListenerBuilder(Events.GuildAuditLogEntryCreate)
   .setId("timeout-broadcast");
 
+/**
+ * Discriminated union to ease the processing of the audit log entry change
+ * object.
+ */
 type TimeoutDetails = {
   type: "issued";
   until: Date;
@@ -102,6 +107,46 @@ function formatEmbed(
   return embed;
 }
 
+/**
+ * Handle sending the embed to both channels. If one fails, still attempt to
+ * send to the other. Return true if there was no issue, else false (some kind
+ * of error happened).
+ */
+async function sendEmbedToChannels(
+  dmChannel: DMChannel,
+  broadcastChannel: GuildTextBasedChannel,
+  embed: EmbedBuilder,
+  targetUsername: string,
+): Promise<boolean> {
+  const payload: MessageCreateOptions = {
+    embeds: [embed],
+    flags: MessageFlags.SuppressNotifications,
+  };
+
+  let failed: boolean = false;
+
+  try {
+    await dmChannel.send(payload);
+    log.debug(`DM'ed @${targetUsername} reason for timeout.`);
+  }
+  catch (error) {
+    log.error(`failed to DM @${targetUsername} timeout details.`);
+    console.error(error);
+    failed = true;
+  }
+  try {
+    await broadcastChannel.send(payload);
+    log.debug(`broadcasted timeout in #${broadcastChannel.name}.`);
+  }
+  catch (error) {
+    log.error(`failed to broadcast timeout details for @${targetUsername}`);
+    console.error(error);
+    failed = true;
+  }
+
+  return !failed;
+}
+
 timeoutBroadcast.execute(async (auditLogEntry, guild) => {
   if (guild.id !== config.YUNG_KAI_WORLD_GID) return false;
 
@@ -123,38 +168,21 @@ timeoutBroadcast.execute(async (auditLogEntry, guild) => {
   }
 
   const embed = formatEmbed(details, executor, target, guild);
-  const payload: MessageCreateOptions = {
-    embeds: [embed],
-    flags: MessageFlags.SuppressNotifications,
-  };
+  const targetUsername = target.user.username;
 
-  const username = target.user.username;
-  let failed: boolean = false;
-  try {
-    await dmChannel.send(payload);
-    log.debug(`DM'ed @${username} reason for timeout.`);
-  }
-  catch (error) {
-    log.error(`failed to DM @${username} timeout details.`);
-    console.error(error);
-    failed = true;
-  }
-  try {
-    await broadcastChannel.send(payload);
-    log.debug(`broadcasted timeout in #${broadcastChannel.name}.`);
-  }
-  catch (error) {
-    log.error(`failed to broadcast timeout details for @${username}`);
-    console.error(error);
-    failed = true;
-  }
-  if (failed) return false;
+  const success = await sendEmbedToChannels(
+    dmChannel,
+    broadcastChannel,
+    embed,
+    targetUsername,
+  );
+  if (!success) return false;
 
   if (details.type === "issued") {
-    log.info(`reported timeout issued for @${username}.`);
+    log.info(`reported timeout issued for @${targetUsername}.`);
   }
   else if (details.type === "removed") {
-    log.info(`reported timeout removed for @${username}.`);
+    log.info(`reported timeout removed for @${targetUsername}.`);
   }
   return true;
 });

--- a/tests/controllers/users/klee/dab.listener.test.ts
+++ b/tests/controllers/users/klee/dab.listener.test.ts
@@ -1,6 +1,6 @@
 import onDabSpec from "../../../../src/controllers/users/klee/dab.listener";
 import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
-import { MockMessage, addMockGetter } from "../../../test-utils";
+import { MockMessage } from "../../../test-utils";
 
 describe("dab listener", () => {
   let mock: MockMessage;
@@ -21,8 +21,7 @@ describe("dab listener", () => {
   });
 
   it("should react with neko L in pollution-immune channel", async () => {
-    addMockGetter(mock.message, "channel", { name: "general" });
-    mock.mockContent("dab");
+    mock.mockContent("dab").mockChannel({ name: "general" });
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_L);
   });


### PR DESCRIPTION
Fix to #73.

Previously, the sending to DM is directly followed by the sending to the broadcast channel without any error handling. I observed that the DM send can fail (for example, if the user rejects DMs from non-friends), and when it does, the thrown error stops any attempt at sending to the broadcast channel despite that having no problem. Now, both are wrapped in `try`-`catch` blocks such that both are still run even if one fails.