### PR TITLE
Add /timeouts so people can see timed out users

### DIFF
--- a/src/controllers/moderation/list-timeouts.command.ts
+++ b/src/controllers/moderation/list-timeouts.command.ts
@@ -2,23 +2,20 @@ import {
   EmbedBuilder,
   GuildMember,
   SlashCommandBuilder,
-  TimestampStyles,
-  time,
   userMention,
 } from "discord.js";
 
 import getLogger from "../../logger";
 import { CommandBuilder } from "../../types/command.types";
 import { formatContext } from "../../utils/logging.utils";
-import { toBulletedList } from "../../utils/markdown.utils";
+import { timestampPair, toBulletedList } from "../../utils/markdown.utils";
 
 const log = getLogger(__filename);
 
 function formatTimedOutMember(member: GuildMember): string {
   const mention = userMention(member.id);
   const until = member.communicationDisabledUntil!;
-  const untilMention = time(until);
-  const untilRelative = time(until, TimestampStyles.RelativeTime);
+  const [untilMention, untilRelative] = timestampPair(until);
   return `${mention} until ${untilMention} (${untilRelative})`;
 }
 

--- a/src/controllers/moderation/list-timeouts.command.ts
+++ b/src/controllers/moderation/list-timeouts.command.ts
@@ -1,0 +1,63 @@
+import {
+  EmbedBuilder,
+  GuildMember,
+  SlashCommandBuilder,
+  TimestampStyles,
+  time,
+  userMention,
+} from "discord.js";
+
+import getLogger from "../../logger";
+import { CommandBuilder } from "../../types/command.types";
+import { formatContext } from "../../utils/logging.utils";
+import { toBulletedList } from "../../utils/markdown.utils";
+
+const log = getLogger(__filename);
+
+function formatTimedOutMember(member: GuildMember): string {
+  const mention = userMention(member.id);
+  const until = member.communicationDisabledUntil!;
+  const untilMention = time(until);
+  const untilRelative = time(until, TimestampStyles.RelativeTime);
+  return `${mention} until ${untilMention} (${untilRelative})`;
+}
+
+const listTimeouts = new CommandBuilder();
+
+listTimeouts.define(new SlashCommandBuilder()
+  .setName("timeouts")
+  .setDescription("List members that are currently timed out."),
+);
+
+listTimeouts.execute(async interaction => {
+  const now = new Date();
+
+  const members = await interaction.guild!.members.fetch();
+  const membersWithTimeout = members.filter(member => {
+    const { communicationDisabledUntil: expiration } = member;
+    // NOTE: As long as a member has been timed out before, the property can
+    // exist on the object (non-null), so we have to check if the timeout is
+    // expired.
+    return expiration && expiration > now;
+  });
+  const entries = membersWithTimeout.map(formatTimedOutMember);
+
+  const description = entries.length === 0
+    ? "No members are currently timed out!"
+    : toBulletedList(entries);
+
+  const embed = new EmbedBuilder()
+    .setTitle("Current Timeouts")
+    .setDescription(description);
+
+  await interaction.reply({
+    embeds: [embed],
+    allowedMentions: { repliedUser: false, parse: [] },
+  });
+
+  const context = formatContext(interaction);
+  log.info(`${context}: revealed ${entries.length} members with timeouts.`);
+});
+
+const listTimeoutsSpec = listTimeouts.toSpec();
+export default listTimeoutsSpec;

--- a/src/utils/markdown.utils.ts
+++ b/src/utils/markdown.utils.ts
@@ -1,7 +1,12 @@
 // Also see:
 // https://v13.discordjs.guide/miscellaneous/parsing-mention-arguments.html
 
-import { TimestampStylesString, userMention } from "discord.js";
+import {
+  TimestampStyles,
+  TimestampStylesString,
+  time,
+  userMention,
+} from "discord.js";
 
 export type Mentionable = {
   type: "user";
@@ -55,9 +60,20 @@ export function joinUserMentions(userIds?: Iterable<string>): string {
 }
 
 export type TimestampMention<F extends TimestampStylesString | null = null>
-  = F extends null ? `<t:${number}>` : `<t:${number}:${F}>`;
+  = F extends null ? `<t:${bigint}>` : `<t:${bigint}:${F}>`;
 
 export function toBulletedList(lines: string[], level: number = 0): string {
   const indent = "  ".repeat(level);
   return lines.map(line => `${indent}* ${line}`).join("\n");
+}
+
+/**
+ * Return a timestamp mention along with its relative version. Both are usually
+ * used together for formatting purposes, so might as well make this is a
+ * shorthand helper.
+ */
+export function timestampPair(
+  date: Date,
+): [basic: TimestampMention, relative: TimestampMention<"R">] {
+  return [time(date), time(date, TimestampStyles.RelativeTime)];
 }

--- a/tests/controllers/moderation/list-timeouts.command.test.ts
+++ b/tests/controllers/moderation/list-timeouts.command.test.ts
@@ -1,0 +1,83 @@
+import {
+  Collection,
+  EmbedBuilder,
+  GuildMember,
+  time,
+  userMention,
+} from "discord.js";
+
+import { Matcher } from "jest-mock-extended";
+import listTimeoutsSpec from "../../../src/controllers/moderation/list-timeouts.command";
+import { addDateSeconds } from "../../../src/utils/dates.utils";
+import { MockInteraction } from "../../test-utils";
+
+const now = new Date();
+
+const mockTimedOut1 = {
+  id: "123456789",
+  communicationDisabledUntil: addDateSeconds(now, 4242),
+} as GuildMember;
+
+const mockTimedOut2 = {
+  id: "987654321",
+  communicationDisabledUntil: addDateSeconds(now, 6000),
+} as GuildMember;
+
+const mockNotTimedOut = {
+  id: "4242424242",
+} as GuildMember;
+
+const mockTimeoutExpired = {
+  id: "4455667788",
+  communicationDisabledUntil: new Date(0),
+} as GuildMember;
+
+it("should list all timeouts", async () => {
+  const mock = new MockInteraction(listTimeoutsSpec);
+  mock.interaction.guild!.members.fetch.mockResolvedValueOnce(
+    new Collection([
+      [mockTimedOut1.id, mockTimedOut1],
+      [mockTimedOut2.id, mockTimedOut2],
+      [mockNotTimedOut.id, mockNotTimedOut],
+      [mockTimeoutExpired.id, mockTimeoutExpired],
+    ]),
+  );
+
+  await mock.simulateCommand();
+
+  const embedMatcher = new Matcher<EmbedBuilder>(embed => {
+    const mention1 = userMention(mockTimedOut1.id);
+    const mention2 = userMention(mockTimedOut2.id);
+    const timestamp1 = time(mockTimedOut1.communicationDisabledUntil!);
+    const timestamp2 = time(mockTimedOut2.communicationDisabledUntil!);
+
+    return [mention1, mention2, timestamp1, timestamp2].every(mention => {
+      return embed.data.description?.includes(mention);
+    });
+  }, "embed matcher");
+  mock.expectRepliedWith({
+    // @ts-expect-error Expects APIEmbed but is actually EmbedBuilder.
+    embeds: [embedMatcher],
+    allowedMentions: { repliedUser: false, parse: [] },
+  });
+});
+
+it("should still have a description when no users are timed out", async () => {
+  const mock = new MockInteraction(listTimeoutsSpec);
+  mock.interaction.guild!.members.fetch.mockResolvedValueOnce(
+    new Collection([
+      [mockNotTimedOut.id, mockNotTimedOut],
+    ]),
+  );
+
+  await mock.simulateCommand();
+
+  const embedMatcher = new Matcher<EmbedBuilder>(embed => {
+    return !!embed.data?.description;
+  }, "embed matcher");
+  mock.expectRepliedWith({
+    // @ts-expect-error Expects APIEmbed but is actually EmbedBuilder.
+    embeds: [embedMatcher],
+    allowedMentions: { repliedUser: false, parse: [] },
+  });
+});

--- a/tests/utils/markdown.utils.test.ts
+++ b/tests/utils/markdown.utils.test.ts
@@ -1,10 +1,12 @@
 jest.mock("../../src/utils/dates.utils");
 
+import { TimestampStyles, time } from "discord.js";
 import { toUnixSeconds } from "../../src/utils/dates.utils";
 import {
   Mentionable,
   joinUserMentions,
   parseMention,
+  timestampPair,
   toBulletedList,
 } from "../../src/utils/markdown.utils";
 
@@ -79,5 +81,14 @@ describe("parsing mentionables", () => {
         expect(result).toEqual(null);
       });
     }
+  });
+});
+
+describe("timestamp-related utilities", () => {
+  it("should return a pair of timestamp mentions", () => {
+    const date = new Date();
+    const result = timestampPair(date);
+    const expected = [time(date), time(date, TimestampStyles.RelativeTime)];
+    expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
Title. Kind of a continuation to #73 in that it helps make timeouts more transparent.

**Other changes:**
* Added a `timestampPair` helper to turn into a one-liner the all-too-common pattern of getting a timestamp mention and then its relative version.