### PR TITLE
Still try to DM if broadcast channel not found

### DIFF
--- a/src/controllers/moderation/timeout-broadcast.listener.ts
+++ b/src/controllers/moderation/timeout-broadcast.listener.ts
@@ -114,7 +114,7 @@ function formatEmbed(
  */
 async function sendEmbedToChannels(
   dmChannel: DMChannel,
-  broadcastChannel: GuildTextBasedChannel,
+  broadcastChannel: GuildTextBasedChannel | null,
   embed: EmbedBuilder,
   targetUsername: string,
 ): Promise<boolean> {
@@ -134,9 +134,17 @@ async function sendEmbedToChannels(
     console.error(error);
     failed = true;
   }
+
+
   try {
-    await broadcastChannel.send(payload);
-    log.debug(`broadcasted timeout in #${broadcastChannel.name}.`);
+    if (!broadcastChannel) {
+      log.error(`no channel found with CID=${config.BOT_SPAM_CID}.`);
+      failed = true;
+    }
+    else {
+      await broadcastChannel.send(payload);
+      log.debug(`broadcasted timeout in #${broadcastChannel.name}.`);
+    }
   }
   catch (error) {
     log.error(`failed to broadcast timeout details for @${targetUsername}`);
@@ -162,10 +170,6 @@ timeoutBroadcast.execute(async (auditLogEntry, guild) => {
   const dmChannel = await getDMChannel(target);
   const broadcastChannel = await guild.channels.fetch(config.BOT_SPAM_CID) as
     GuildTextBasedChannel | null;
-  if (!broadcastChannel) {
-    log.error(`no channel found with CID=${config.BOT_SPAM_CID}.`);
-    return false;
-  }
 
   const embed = formatEmbed(details, executor, target, guild);
   const targetUsername = target.user.username;

--- a/tests/controllers/moderation/timeout-broadcast.listener.test.ts
+++ b/tests/controllers/moderation/timeout-broadcast.listener.test.ts
@@ -172,11 +172,11 @@ const removedEmbedMatcher = new Matcher<EmbedBuilder>(embed => {
 }, "removed embed matcher");
 
 describe("error handling", () => {
-  it("should do nothing if broadcast channel can't be  found", async () => {
+  it("should still try to DM if broadcast channel not found", async () => {
     // @ts-expect-error fetch() can resolve to null. IDK why it says it can't.
     jest.mocked(mockGuild.channels.fetch).mockResolvedValueOnce(null);
     await simulateEvent(mockTimeoutIssuedEntry, mockGuild);
-    expect(mockDMChannel.send).not.toHaveBeenCalled();
+    expect(mockDMChannel.send).toHaveBeenCalled();
     expect(mockBroadcastChannel.send).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
A minor fix to #73/continuation of #74 to make `timeout-broadcast` a bit more robust. Previously, the listener would short-circuit `false` if the broadcast channel isn't found. However, it would make sense for it to still try to DM the victim the timeout embed even if the broadcast channel doesn't exist. Thus, the logic has been updated such that a broadcast channel not being found doesn't affect sending the DM.