### PR TITLE
Assume seconds if no unit provided to /countdown

### DIFF
--- a/src/controllers/convenience/countdown.command.ts
+++ b/src/controllers/convenience/countdown.command.ts
@@ -19,6 +19,11 @@ import { addEphemeralOption } from "../../utils/options.utils";
 const log = getLogger(__filename);
 
 function durationToSeconds(humanReadableDuration: string): number | null {
+  // If no unit is specified, assume it means seconds. parseDuration seems to
+  // interpret lone numbers as milliseconds, so a lone "10" becomes 0.01
+  // seconds, which would get rejected to the confusion of the caller.
+  const asNumber = Number(humanReadableDuration);
+  if (!isNaN(asNumber)) return asNumber;
   const seconds = parseDuration(humanReadableDuration, "sec");
   return seconds ?? null;
 }

--- a/tests/controllers/convenience/countdown.command.test.ts
+++ b/tests/controllers/convenience/countdown.command.test.ts
@@ -1,0 +1,89 @@
+jest.mock("../../../src/utils/dates.utils");
+
+import { userMention } from "discord.js";
+
+import countdownSpec from "../../../src/controllers/convenience/countdown.command";
+import { formatHoursMinsSeconds } from "../../../src/utils/dates.utils";
+import { MockInteraction } from "../../test-utils";
+
+const mockedFormatHoursMinsSeconds = jest.mocked(formatHoursMinsSeconds);
+
+let mock: MockInteraction;
+
+beforeEach(() => {
+  mock = new MockInteraction(countdownSpec);
+  jest.useFakeTimers();
+  jest.spyOn(global, "setTimeout");
+  // formatHoursMinsSeconds is our own dependency, so we don't want to couple
+  // countdown's correctness with its correctness. Just mock its return value.
+  mockedFormatHoursMinsSeconds.mockReturnValue("DUMMY-FORMATTED-TIME");
+});
+
+afterEach(jest.useRealTimers);
+
+describe("processing human-readable inputs", () => {
+  const dummyUid = "123456789";
+
+  // ARRANGE.
+  function mockCalledWithDuration(humanReadableDuration: string): void {
+    mock
+      .mockCaller({ uid: dummyUid })
+      .mockOption("String", "duration", humanReadableDuration);
+  }
+
+  // ASSERT.
+  function expectCountdownSuccess(msec: number): void {
+    mock.expectRepliedWith({
+      // TODO: somehow check for the timestamp part?
+      content: expect.stringContaining(
+        "Counting down to DUMMY-FORMATTED-TIME from now.",
+      ),
+    });
+    expect(setTimeout).toHaveBeenCalledWith(expect.any(Function), msec);
+    jest.runAllTimers();
+    expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
+      `${userMention(dummyUid)}, your countdown has expired!`,
+    );
+  }
+
+  const TEST_CASES: [string, number][] = [
+    ["10s", 10 * 1000],
+    ["2 min", 2 * 60 * 1000],
+    ["5min 32sec", (5 * 60 + 32) * 1000],
+  ] as const;
+
+  for (const [humanReadableDuration, msec] of TEST_CASES) {
+    it(`should accept ${humanReadableDuration}`, async () => {
+      mockCalledWithDuration(humanReadableDuration);
+      await mock.simulateCommand();
+      expectCountdownSuccess(msec);
+    });
+  }
+
+  it("should treat an input without units as seconds", async () => {
+    mockCalledWithDuration("10");
+    await mock.simulateCommand();
+    expectCountdownSuccess(10 * 1000);
+  });
+});
+
+describe("error handling", () => {
+  it("should reject miniscule durations", async () => {
+    mock.mockOption("String", "duration", "1");
+    await mock.simulateCommand();
+    mock.expectRepliedWith({ ephemeral: true });
+    expect(setTimeout).not.toHaveBeenCalled();
+  });
+
+  it("should alert the caller if failed to parse duration", async () => {
+    mock.mockOption("String", "duration", "lorem ipsum");
+    await mock.simulateCommand();
+    mock.expectRepliedWith({
+      content: expect.stringContaining("lorem ipsum"), // Some mention of it.
+      ephemeral: true,
+    });
+    expect(setTimeout).not.toHaveBeenCalled();
+  });
+});
+
+// TODO: Add a testEphemeralOption that mirrors testBroadcastOption.


### PR DESCRIPTION
Title. I noticed when trying to use a simple `10` as the input to the `duration` option that the command rejects it saying it's too small. This was because `parseDuration` interprets unitless quantities as milliseconds by default, so 10 became 0.01 seconds. This PR makes it so that the command will default to interpreting unitless strings as seconds.

This PR also introduces tests to this new feature as well as existing features of `/countdown` since they were missing.