### PR TITLE
Reply to interaction if command runner not found

### DIFF
--- a/src/bot/listeners/command.listener.ts
+++ b/src/bot/listeners/command.listener.ts
@@ -1,4 +1,4 @@
-// >> THIS MODULE IS WHAT MAKE SLASH COMMANDS POSSIBLE. <<
+// >> THIS MODULE IS WHAT MAKES SLASH COMMANDS POSSIBLE. <<
 
 // Remember that command invocations are themselves a type of event,
 // `Events.InteractionCreate`. This listener handles these events and dispatches
@@ -7,8 +7,8 @@
 import { Events, Interaction } from "discord.js";
 
 import getLogger from "../../logger";
+import { ClientWithIntentsAndRunnersABC } from "../../types/client.abc";
 import { ListenerBuilder, ListenerSpec } from "../../types/listener.types";
-import { BotClient } from "../client";
 
 const log = getLogger(__filename);
 
@@ -17,12 +17,18 @@ async function dispatchCommand(interaction: Interaction): Promise<void> {
     return;
   }
 
-  const client = interaction.client as BotClient;
-  const commandName = interaction.commandName;
+  const client = interaction.client as ClientWithIntentsAndRunnersABC;
+  const { commandName } = interaction;
   const runner = client.commandRunners.get(commandName);
 
   if (!runner) {
     log.error(`no command named '${commandName}' found.`);
+    if (interaction.isRepliable()) {
+      await interaction.reply({
+        content: "It looks like that command doesn't exist anymore! Sorry!",
+        ephemeral: true,
+      });
+    }
     return;
   }
 

--- a/tests/bot/listeners/command.listener.test.ts
+++ b/tests/bot/listeners/command.listener.test.ts
@@ -1,0 +1,134 @@
+import {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Interaction,
+  UserContextMenuCommandInteraction,
+} from "discord.js";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+
+import { CommandRunner } from "../../../src/bot/command.runner";
+import { ListenerRunner } from "../../../src/bot/listener.runner";
+import commandDispatcherSpec from "../../../src/bot/listeners/command.listener";
+import { TestClient, addMockGetter } from "../../test-utils";
+
+const testRunner = new ListenerRunner(commandDispatcherSpec);
+/**
+ * UUT: listener execution pipeline entry point.
+ *
+ * TODO: Is this still coupling dependencies? What if ListenerRunner itself is
+ * faulty?
+ */
+const simulateEvent = testRunner.callbackToRegister;
+
+const dummyCommandName = "dummy-command";
+
+const mockedRun = jest.fn();
+const mockedResolveAutocomplete = jest.fn();
+
+function arrangeMockClient(interaction: DeepMockProxy<Interaction>): void {
+  const dummyRunner = {
+    run: mockedRun,
+    resolveAutocomplete: mockedResolveAutocomplete,
+  } as unknown as CommandRunner;
+  const testClient = new TestClient();
+  testClient.commandRunners.set(dummyCommandName, dummyRunner);
+  addMockGetter(interaction, "client", testClient);
+}
+
+function arrangeMockCommandInteraction(
+  commandName: string,
+): DeepMockProxy<ChatInputCommandInteraction> {
+  const interaction = mockDeep<ChatInputCommandInteraction>();
+  interaction.isChatInputCommand.mockReturnValue(true);
+  interaction.isAutocomplete.mockReturnValue(false);
+  interaction.isRepliable.mockReturnValue(true);
+  interaction.commandName = commandName;
+  arrangeMockClient(interaction);
+  return interaction;
+}
+
+function arrangeMockAutocompleteInteraction(
+  commandName: string,
+): DeepMockProxy<AutocompleteInteraction> {
+  const interaction = mockDeep<AutocompleteInteraction>();
+  interaction.isAutocomplete.mockReturnValue(true);
+  interaction.isChatInputCommand.mockReturnValue(false);
+  interaction.isRepliable.mockReturnValue(false);
+  interaction.commandName = commandName;
+  arrangeMockClient(interaction);
+  return interaction;
+}
+
+describe("slash command dispatching", () => {
+  let interaction: DeepMockProxy<ChatInputCommandInteraction>;
+  beforeEach(() => {
+    interaction = arrangeMockCommandInteraction(dummyCommandName);
+  });
+
+  it("should execute the slash command runner", async () => {
+    await simulateEvent(interaction);
+    expect(mockedRun).toHaveBeenCalledWith(interaction);
+  });
+
+  it("should fail gracefully when runner errors", async () => {
+    mockedRun.mockRejectedValue("DUMMY-ERROR");
+    await simulateEvent(interaction);
+    expect(mockedRun).toHaveBeenCalledWith(interaction);
+  });
+});
+
+describe("autocomplete dispatching", () => {
+  let interaction: DeepMockProxy<AutocompleteInteraction>;
+  beforeEach(() => {
+    interaction = arrangeMockAutocompleteInteraction(dummyCommandName);
+  });
+
+  it("should execute the autocomplete handler", async () => {
+    await simulateEvent(interaction);
+    expect(mockedResolveAutocomplete).toHaveBeenCalledWith(interaction);
+  });
+
+  it("should fail gracefully when handler errors", async () => {
+    mockedResolveAutocomplete.mockRejectedValue("DUMMY-ERROR");
+    await simulateEvent(interaction);
+    expect(mockedResolveAutocomplete).toHaveBeenCalledWith(interaction);
+  });
+});
+
+describe("unknown interactions", () => {
+  it("should fail gracefully if runner is not found", async () => {
+    const interaction = arrangeMockAutocompleteInteraction("unknown-command");
+
+    await simulateEvent(interaction);
+
+    expect(mockedRun).not.toHaveBeenCalled();
+    expect(mockedResolveAutocomplete).not.toHaveBeenCalled();
+  });
+
+  it("should tell caller if command doesn't exist anymore", async () => {
+    const interaction = arrangeMockCommandInteraction("unknown-command");
+
+    await simulateEvent(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith(expect.objectContaining({
+      content: "It looks like that command doesn't exist anymore! Sorry!",
+      ephemeral: true,
+    }));
+    expect(mockedRun).not.toHaveBeenCalled();
+    expect(mockedResolveAutocomplete).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing if interaction is other type", async () => {
+    // TODO: If we ever do implement handling this type of interaction, this
+    // test needs to be changed.
+    const interaction = mockDeep<UserContextMenuCommandInteraction>();
+    interaction.isChatInputCommand.mockReturnValue(false);
+    interaction.isAutocomplete.mockReturnValue(false);
+    interaction.isRepliable.mockReturnValue(false);
+
+    await simulateEvent(interaction);
+
+    expect(mockedRun).not.toHaveBeenCalled();
+    expect(mockedResolveAutocomplete).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This replaces the unhelpful default response that the execution pipeline falls back to when the interaction is found to not have been replied to. Also added tests for the command dispatcher event listener.