### PR TITLE
Implement rate limiting on timeout spam

### DIFF
--- a/src/controllers/moderation/timeout/timeout-broadcast.listener.ts
+++ b/src/controllers/moderation/timeout/timeout-broadcast.listener.ts
@@ -125,16 +125,13 @@ class TimeoutLogEventHandler {
     const rateLimitExceeded = !timeoutService.reportIssued(this.executor.id);
     const targetIsImmune = timeoutService.isImmune(this.target.id);
 
-    if (rateLimitExceeded) {
+    if (rateLimitExceeded && !alphaOverride) {
       log.info(
-        `@${executorUsername} is rate limited, ` +
+        `Non-alpha @${executorUsername} is rate limited, ` +
         `undoing timeout for @${targetUsername}.`,
       );
       await this.undoTargetTimeout();
-      // Alpha mods are rate-limited, but the bot can't time them out.
-      if (!alphaOverride) {
-        await this.timeOutExecutorForSpamming();
-      }
+      await this.timeOutExecutorForSpamming();
       return;
     }
 

--- a/src/services/timeout.service.ts
+++ b/src/services/timeout.service.ts
@@ -1,12 +1,15 @@
 import { Collection, userMention } from "discord.js";
 
 import getLogger from "../logger";
+import { TokenBucket } from "../utils/algorithms.utils";
 
 const log = getLogger(__filename);
 
 export class TimeoutService {
   /** UID-to-expiration mapping of members temporarily immune to timeouts. */
   private immunities = new Collection<string, Date>();
+  /** Mapping of UID to rate-limit manager to prevent spamming of timeouts. */
+  private spamTracker = new Collection<string, TokenBucket<0.1, 5>>();
 
   public grantImmunity(uid: string, until: Date): void {
     this.immunities.set(uid, until);
@@ -35,6 +38,20 @@ export class TimeoutService {
   public listImmunities(): Collection<string, Date> {
     const now = new Date();
     return this.immunities.filter(expiration => expiration > now);
+  }
+
+  /**
+   * Report a timeout issued event. Return whether the timeout is within the
+   * rate limit. That is, return false if the timeout has exceeded the rate
+   * limit and thus punishment should be issued.
+   */
+  public reportIssued(executorId: string): boolean {
+    let bucket = this.spamTracker.get(executorId);
+    if (!bucket) {
+      bucket = new TokenBucket(0.1, 5);
+      this.spamTracker.set(executorId, bucket);
+    }
+    return bucket.consume();
   }
 }
 

--- a/src/services/timeout.service.ts
+++ b/src/services/timeout.service.ts
@@ -8,8 +8,13 @@ const log = getLogger(__filename);
 export class TimeoutService {
   /** UID-to-expiration mapping of members temporarily immune to timeouts. */
   private immunities = new Collection<string, Date>();
-  /** Mapping of UID to rate-limit manager to prevent spamming of timeouts. */
-  private spamTracker = new Collection<string, TokenBucket<0.1, 5>>();
+  /**
+   * Mapping of UID to rate-limit manager to prevent spamming of timeouts.
+   *
+   * - rate=0.1: Regain 1 timeout quota every 10 seconds.
+   * - capacity=3: Time out at most 3 users in quick succession.
+   */
+  private spamTracker = new Collection<string, TokenBucket<0.1, 3>>();
 
   public grantImmunity(uid: string, until: Date): void {
     this.immunities.set(uid, until);
@@ -48,7 +53,7 @@ export class TimeoutService {
   public reportIssued(executorId: string): boolean {
     let bucket = this.spamTracker.get(executorId);
     if (!bucket) {
-      bucket = new TokenBucket(0.1, 5);
+      bucket = new TokenBucket(0.1, 3);
       this.spamTracker.set(executorId, bucket);
     }
     return bucket.consume();

--- a/src/types/errors.types.ts
+++ b/src/types/errors.types.ts
@@ -1,0 +1,20 @@
+import { DiscordAPIError } from "discord.js";
+
+/**
+ * Utility type for narrowing discord.js' `DiscordAPIError` to have the literal
+ * opcode for the `code` property.
+ *
+ * See: https://discord.com/developers/docs/topics/opcodes-and-status-codes
+ */
+export type DiscordAPIErrorWithCode<Opcode extends number>
+  = DiscordAPIError & { code: Opcode };
+
+export function isCannotSendToThisUser(error: unknown):
+  error is DiscordAPIErrorWithCode<50007> {
+  return error instanceof DiscordAPIError && error.code === 50007;
+}
+
+export function isMissingPermissions(error: unknown):
+  error is DiscordAPIErrorWithCode<50013> {
+  return error instanceof DiscordAPIError && error.code === 50013;
+}

--- a/src/utils/algorithms.utils.ts
+++ b/src/utils/algorithms.utils.ts
@@ -5,9 +5,10 @@
  */
 export class TokenBucket<Rate extends number, Capacity extends number> {
   /** Current number of tokens in the bucket. */
-  private tokens = 0;
-  /** Timestamp of the last token refill */
-  private lastRefill = Date.now();
+  private tokens;
+  /** Timestamp of the last token refill. */
+  private lastRefill;
+
   constructor(
     /**
      * Tokens to refill per second. Equivalent to the number of actions
@@ -27,6 +28,8 @@ export class TokenBucket<Rate extends number, Capacity extends number> {
     if (this.capacity <= 0) {
       throw new RangeError("capacity should be positive");
     }
+    this.tokens = capacity as number;
+    this.lastRefill = Date.now();
   }
 
   /**

--- a/src/utils/algorithms.utils.ts
+++ b/src/utils/algorithms.utils.ts
@@ -1,0 +1,57 @@
+/**
+ * Implements an algorithm for rate-limiting.
+ *
+ * See: https://en.wikipedia.org/wiki/Token_bucket
+ */
+export class TokenBucket<Rate extends number, Capacity extends number> {
+  /** Current number of tokens in the bucket. */
+  private tokens = 0;
+  /** Timestamp of the last token refill */
+  private lastRefill = Date.now();
+  constructor(
+    /**
+     * Tokens to refill per second. Equivalent to the number of actions
+     * permitted per second.
+     */
+    public readonly rate: Rate,
+    /**
+     * Maximum tokens in the bucket. Equivalent to the burst allowance; that is,
+     * how many actions the consumer can execute at once before exceeding the
+     * rate limit.
+     */
+    public readonly capacity: Capacity,
+  ) {
+    if (this.rate <= 0) {
+      throw new RangeError("rate should be positive");
+    }
+    if (this.capacity <= 0) {
+      throw new RangeError("capacity should be positive");
+    }
+  }
+
+  /**
+   * Take some kind of action that should be rate-limited. Return whether the
+   * action is allowed i.e. false means the action has exceeded its rate limit
+   * and is not prohibited.
+   */
+  public consume(): boolean {
+    this.refill();
+    if (this.tokens >= 1) {
+      this.tokens -= 1;
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Refill the bucket with tokens based on how much time has elapsed since the
+   * last refill.
+   */
+  private refill(): void {
+    const now = Date.now();
+    const elapsedSeconds = (now - this.lastRefill) / 1000;
+    const newTokens = Math.round(this.tokens + elapsedSeconds * this.rate);
+    this.tokens = Math.min(this.capacity, newTokens);
+    this.lastRefill = now;
+  }
+}

--- a/tests/controllers/moderation/timeout/timeout-broadcast.listener.test.ts
+++ b/tests/controllers/moderation/timeout/timeout-broadcast.listener.test.ts
@@ -335,14 +335,14 @@ describe("timeout rate-limiting", () => {
     );
   });
 
-  it("should still rate limit alpha mods", async () => {
+  it("should not rate limit alpha mods", async () => {
     mockTimeoutApplicability({
       immunity: false,
       rateLimited: true,
       alphaOverride: true,
     });
     await simulateEvent(mockTimeoutIssuedEntry, mockGuild);
-    expect(dummyTarget.timeout).toHaveBeenCalledWith(null);
+    expect(dummyTarget.timeout).not.toHaveBeenCalledWith(null);
   });
 
   it("should not attempt to time alpha mods even if rate limited", async () => {

--- a/tests/utils/algorithms.utils.test.ts
+++ b/tests/utils/algorithms.utils.test.ts
@@ -1,0 +1,41 @@
+import { TokenBucket } from "../../src/utils/algorithms.utils";
+
+describe("token bucket rate-limiting algorithm", () => {
+  describe("constructor error handling", () => {
+    it("should reject non-positive rates", () => {
+      expect(() => new TokenBucket(0, 10)).toThrow(RangeError);
+    });
+
+    it("should reject non-positive capacities", () => {
+      expect(() => new TokenBucket(2, 0)).toThrow(RangeError);
+    });
+  });
+
+  describe("consuming tokens", () => {
+    it("should allow consuming tokens within capacity", () => {
+      const tokenBucket = new TokenBucket(1, 10);
+      expect(tokenBucket.consume()).toEqual(true);
+    });
+
+    it("should block consuming tokens beyond capacity", () => {
+      const tokenBucket = new TokenBucket(1, 1);
+      expect(tokenBucket.consume()).toEqual(true);
+      expect(tokenBucket.consume()).toEqual(false);
+    });
+
+    it("should refill tokens over time", () => {
+      jest.useFakeTimers();
+
+      const tokenBucket = new TokenBucket(1, 1);
+      expect(tokenBucket.consume()).toEqual(true);
+
+      jest.advanceTimersByTime(500); // Half a second.
+      expect(tokenBucket.consume()).toEqual(true);
+
+      jest.advanceTimersByTime(1000); // One second.
+      expect(tokenBucket.consume()).toEqual(true);
+
+      jest.useRealTimers();
+    });
+  });
+});


### PR DESCRIPTION
## Feature

The bot now detects timeout spamming (excessive timeouts within a certain time interval). If an executor exceeds the rate limit, the target's timeout will be undone and the bot will time the executor out in retaliation. Privilege levels of `ALPHA_MOD` and higher are exempt from both effects.

The rate limiting is implemented with the [token bucket algorithm](https://en.wikipedia.org/wiki/Token_bucket). The `TokenBucket` used for timeout spam detection has initial parameters `rate=0.1` and `capacity=3`. From the consumer's POV, this means executors regain one timeout "quota" every 10 seconds and can time out up to 3 users in quick succession ("burst").


## Other Changes & Todos

* I identified that sending to DMs can fail if the target has disabled DMs. This results in a [Discord API 50007 error](https://discord.com/developers/docs/topics/opcodes-and-status-codes). This didn't break anything since the code is wrapped in a `try`-`catch`, but the logs would be needlessly flooded with `console.error`. Thus, the bot now just logs a warning instead of printing the error in the specific case that the DM error is a 50007.
* To implement the above, I started on some type guards for narrowing `DiscordAPIError` that can be expanded in future development.
* Fixed some `.mock*Value` => `.mock*ValueOnce` in the `timeout-broadcast` tests. Apparently `clearMocks` is different from `resetMocks` in global Jest configuration. The former, which is all we have at the moment, only resets calls and results, not implementations. The result was that the effects of some `.mock*Value()` setups were persisting between tests. **Enabling `resetMocks` directly breaks some existing tests, so this should be fixed in a separate PR.**