### PR TITLE
Fix duration field in timeout details embed

### DIFF
--- a/src/controllers/moderation/timeout/timeout-broadcast.listener.ts
+++ b/src/controllers/moderation/timeout/timeout-broadcast.listener.ts
@@ -24,7 +24,10 @@ import {
 import timeoutService from "../../../services/timeout.service";
 import { isCannotSendToThisUser } from "../../../types/errors.types";
 import { ListenerBuilder } from "../../../types/listener.types";
-import { formatHoursMinsSeconds } from "../../../utils/dates.utils";
+import {
+  formatHoursMinsSeconds,
+  roundMsecToNearestMinute,
+} from "../../../utils/dates.utils";
 import { getDMChannel } from "../../../utils/interaction.utils";
 import { toBulletedList } from "../../../utils/markdown.utils";
 
@@ -181,7 +184,8 @@ class TimeoutLogEventHandler {
       return;
     }
 
-    const duration = formatHoursMinsSeconds(durationMsec / 1000);
+    const roundedDuration = roundMsecToNearestMinute(durationMsec);
+    const duration = formatHoursMinsSeconds(roundedDuration / 1000);
     const payload: MessageCreateOptions = {
       content:
         `An unusually long timeout of ${bold(duration)} was issued! ` +
@@ -212,10 +216,13 @@ class TimeoutLogEventHandler {
       const relativeTime = time(details.until, TimestampStyles.RelativeTime);
       const { timestamp: created, until } = details;
       const durationMsec = until.getTime() - created.getTime();
+      const roundedDuration = roundMsecToNearestMinute(durationMsec);
+      const duration = formatHoursMinsSeconds(roundedDuration / 1000);
+
       const description = toBulletedList([
         `${bold("For:")} ${userMention(target.id)}`,
         `${bold("By:")} ${userMention(executor.id)}`,
-        `${bold("Duration:")} ${formatHoursMinsSeconds(durationMsec)}`,
+        `${bold("Duration:")} ${duration}`,
         `${bold("Until:")} ${timestamp} (${relativeTime})`,
         `${bold("Reason:")} ${details.reason ?? "(none given)"}`,
       ]);

--- a/src/utils/dates.utils.ts
+++ b/src/utils/dates.utils.ts
@@ -38,6 +38,11 @@ export function toUnixSeconds(date: Date): number {
   return seconds;
 }
 
+/**
+ * Convert a number of seconds to a human-readable string mentioning hours,
+ * minutes, and/or seconds as needed. For example, 3730 seconds returns "1 hour,
+ * 2 minutes, 10 seconds".
+ */
 export function formatHoursMinsSeconds(seconds: number): string {
   function formatHours(): string {
     const hours = Math.floor(seconds / 3600);
@@ -73,6 +78,15 @@ export function formatHoursMinsSeconds(seconds: number): string {
   ].filter(Boolean).join(", ");
 
   return formattedTime || "0 seconds";
+}
+
+/**
+ * Round a number of milliseconds to the nearest multiple of one minute. The
+ * number returned is also in milliseconds.
+ */
+export function roundMsecToNearestMinute(msec: number): number {
+  const minutes = Math.round(msec / (60 * 1000));
+  return minutes * 60 * 1000; // Convert back to milliseconds.
 }
 
 /**

--- a/tests/utils/dates.utils.test.ts
+++ b/tests/utils/dates.utils.test.ts
@@ -3,6 +3,7 @@ import {
   addDateSeconds,
   durationToSeconds,
   formatHoursMinsSeconds,
+  roundMsecToNearestMinute,
   toUnixSeconds,
 } from "../../src/utils/dates.utils";
 
@@ -81,6 +82,18 @@ describe("format hours, minutes, seconds from seconds value", () => {
   it("should properly handle singular nouns", () => {
     const formatted = formatHoursMinsSeconds(3661);
     expect(formatted).toEqual("1 hour, 1 minute, 1 second");
+  });
+});
+
+describe("rounding milliseconds to nearest multiple of 1 minute", () => {
+  it("rounds down to the nearest minute", () => {
+    expect(roundMsecToNearestMinute(70000)).toEqual(60000);
+    expect(roundMsecToNearestMinute(120000)).toEqual(120000);
+  });
+
+  it("rounds up to the nearest minute", () => {
+    expect(roundMsecToNearestMinute(55000)).toEqual(60000);
+    expect(roundMsecToNearestMinute(130000)).toEqual(120000);
   });
 });
 


### PR DESCRIPTION
Fix to the change in #86, where a **Duration** field was computed and added to the "timeout issued" embeds.

There were two problems:

1. I was accidentally passing in milliseconds to `formatHoursMinsSeconds` instead of seconds, so the duration was showing up at 1000x than it should've been.
2. After fixing that, I noticed that using `details.until - details.timeout` is not precise to the millisecond. For example, a 5 minute timeout was showing up as "4 minutes, 59.\<decimals\> seconds" on the embed instead of just 5 minutes. To fix this, I added a `roundMsecToNearestMinute` helper that rounds a millisecond quantity to the nearest multiple of one minute (60000 msec).