### PR TITLE
Add /send and /react to make bot send/react

### DIFF
--- a/src/controllers/dev/react.command.ts
+++ b/src/controllers/dev/react.command.ts
@@ -1,0 +1,98 @@
+import {
+  ChatInputCommandInteraction,
+  Message,
+  SlashCommandBuilder,
+} from "discord.js";
+
+import {
+  RoleLevel,
+  checkPrivilege,
+} from "../../middleware/privilege.middleware";
+import { CommandBuilder } from "../../types/command.types";
+
+const devReact = new CommandBuilder();
+
+devReact.define(new SlashCommandBuilder()
+  .setName("react")
+  .setDescription("Make the bot react to an existing message.")
+  .addStringOption(input => input
+    .setName("emoji")
+    .setDescription("Emoji to react with.")
+    .setRequired(true),
+  )
+  .addStringOption(input => input
+    .setName("message")
+    .setDescription(
+      "Link or ID of message to react to " +
+      "(defaults to last message of current channel).",
+    ),
+  ),
+);
+
+devReact.check(checkPrivilege(RoleLevel.DEV));
+devReact.execute(async interaction => {
+  const emoji = interaction.options.getString("emoji", true);
+  const messageIdentifier = interaction.options.getString("message");
+
+  const message = messageIdentifier
+    ? await fetchMessageByIdentifier(messageIdentifier, interaction)
+    : await fetchMostRecentMessage(interaction);
+  if (!message) return false;
+
+  try {
+    await message.react(emoji);
+  }
+  catch (error) {
+    await interaction.reply({
+      content:
+        `Failed to react with \`${emoji}\`. ` +
+        "Are you sure this is a valid emoji?",
+      ephemeral: true,
+    });
+    return false;
+  }
+
+  await interaction.reply({ content: "👍", ephemeral: true });
+  return true;
+});
+
+async function fetchMessageByIdentifier(
+  messageIdentifier: string,
+  interaction: ChatInputCommandInteraction,
+): Promise<Message | null> {
+  const messageId = extractMessageID(messageIdentifier);
+  if (messageId === null) {
+    await interaction.reply({
+      content: `\`${messageIdentifier}\` does not point to a valid message!`,
+      ephemeral: true,
+    });
+    return null;
+  }
+  const message = await interaction.channel!.messages.fetch(messageId);
+  return message;
+}
+
+async function fetchMostRecentMessage(
+  interaction: ChatInputCommandInteraction,
+): Promise<Message> {
+  const messages = await interaction.channel!.messages.fetch({ limit: 1 });
+  const message = Array.from(messages.values())[0];
+  return message;
+}
+
+function extractMessageID(idOrUrl: string): string | null {
+  const idRegexp = /^\d+$/i;
+  // The string is an ID itself.
+  if (idOrUrl.match(idRegexp)) return idOrUrl;
+
+  // Otherwise see if it's a URL. Specifically, we only care about messages
+  // within guild channels at the moment, hence /channels/.
+  const urlRegexp = /^https:\/\/discord\.com\/channels\/\d+\/\d+\/(\d+)$/i;
+  const match = idOrUrl.match(urlRegexp);
+  if (!match) return null;
+  const [, messageId] = match;
+  return messageId;
+}
+
+const devReactSpec = devReact.toSpec();
+export default devReactSpec;

--- a/src/controllers/dev/send.command.ts
+++ b/src/controllers/dev/send.command.ts
@@ -1,0 +1,55 @@
+import {
+  ChannelType,
+  GuildTextBasedChannel,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+
+import {
+  RoleLevel,
+  checkPrivilege,
+} from "../../middleware/privilege.middleware";
+import { CommandBuilder } from "../../types/command.types";
+
+const devSend = new CommandBuilder();
+
+devSend.define(new SlashCommandBuilder()
+  .setName("send")
+  .setDescription("Make the bot send something somewhere.")
+  .addStringOption(input => input
+    .setName("content")
+    .setDescription("Text to send.")
+    .setRequired(true),
+  )
+  .addChannelOption(input => input
+    .setName("channel")
+    .setDescription("Channel to send to (defaults to current channel).")
+    .addChannelTypes(ChannelType.GuildText),
+  )
+  .addBooleanOption(input => input
+    .setName("enable_mentions")
+    .setDescription("Whether mentions should ping the user."),
+  ),
+);
+
+devSend.check(checkPrivilege(RoleLevel.DEV));
+devSend.execute(async interaction => {
+  const content = interaction.options.getString("content", true);
+  const enableMentions = !!interaction.options.getBoolean("enable_mentions");
+  let channel = interaction.options.getChannel("channel") as
+    GuildTextBasedChannel | null;
+  if (!channel) {
+    channel = interaction.channel as GuildTextBasedChannel;
+  }
+
+  await channel.send({
+    content,
+    allowedMentions: enableMentions ? undefined : { parse: [] },
+    flags: MessageFlags.SuppressNotifications,
+  });
+
+  await interaction.reply({ content: "👍", ephemeral: true });
+});
+
+const devSendSpec = devSend.toSpec();
+export default devSendSpec;

--- a/tests/controllers/dev/react.command.test.ts
+++ b/tests/controllers/dev/react.command.test.ts
@@ -1,0 +1,108 @@
+import { Collection, Message, Snowflake } from "discord.js";
+import { mockDeep } from "jest-mock-extended";
+import config from "../../../src/config";
+import devReactSpec from "../../../src/controllers/dev/react.command";
+import { RoleLevel } from "../../../src/middleware/privilege.middleware";
+import { MockInteraction } from "../../test-utils";
+
+let mock: MockInteraction;
+beforeEach(() => { mock = new MockInteraction(devReactSpec); });
+
+it("should require privilege level >= DEV", async () => {
+  mock
+    .mockCaller({ roleIds: [config.KAI_RID] })
+    .mockOption("String", "emoji", "🥺");
+  await mock.simulateCommand();
+  expect(mock.interaction.channel!.messages.fetch).not.toHaveBeenCalled();
+  mock.expectMentionedMissingPrivilege(RoleLevel.DEV);
+});
+
+it("should react to the most recent message", async () => {
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "emoji", "🤩");
+  const mockMessage = mockDeep<Message<true>>();
+  mock.interaction.channel!.messages.fetch
+    .mockResolvedValueOnce(new Collection([["DUMMY-ID", mockMessage]]));
+
+  await mock.simulateCommand();
+
+  expect(mockMessage.react).toHaveBeenCalledWith("🤩");
+  mock.expectRepliedGenericACK();
+});
+
+it("should react to the specified message (using ID)", async () => {
+  const dummyMessageId = "123456789";
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "emoji", "🫡")
+    .mockOption("String", "message", dummyMessageId);
+  const mockMessage = mockDeep<Message<true>>();
+  // @ts-expect-error Choose Message overload over Collection return type.
+  mock.interaction.channel!.messages.fetch.mockImplementationOnce(id => {
+    if (id as Snowflake === dummyMessageId) {
+      return Promise.resolve(mockMessage);
+    }
+    throw new Error("unrecognized dummy message ID");
+  });
+
+  await mock.simulateCommand();
+
+  expect(mockMessage.react).toHaveBeenCalledWith("🫡");
+  mock.expectRepliedGenericACK();
+});
+
+it("should react to the specified message (using URL)", async () => {
+  const dummyMessageId = "123456789";
+  const dummyUrl = `https://discord.com/channels/3344/6677/${dummyMessageId}`;
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "emoji", "😪")
+    .mockOption("String", "message", dummyUrl);
+  const mockMessage = mockDeep<Message<true>>();
+  // @ts-expect-error Choose Message overload over Collection return type.
+  mock.interaction.channel!.messages.fetch.mockImplementationOnce(id => {
+    if (id as Snowflake === dummyMessageId) {
+      return Promise.resolve(mockMessage);
+    }
+    throw new Error("unrecognized dummy message ID");
+  });
+
+  await mock.simulateCommand();
+
+  expect(mockMessage.react).toHaveBeenCalledWith("😪");
+  mock.expectRepliedGenericACK();
+});
+
+describe("error handling", () => {
+  it("should reject invalid emojis", async () => {
+    mock
+      .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+      .mockOption("String", "emoji", "😨");
+    const mockMessage = mockDeep<Message<true>>();
+    mock.interaction.channel!.messages.fetch
+      .mockResolvedValueOnce(new Collection([["DUMMY-ID", mockMessage]]));
+    mockMessage.react.mockRejectedValueOnce("DUMMY-ERROR");
+
+    await mock.simulateCommand();
+
+    mock.expectRepliedWith({
+      content: expect.stringContaining("Failed to react with `😨`"),
+      ephemeral: true,
+    });
+  });
+
+  it("should reject invalid message identifiers", async () => {
+    mock
+      .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+      .mockOption("String", "emoji", "😨")
+      .mockOption("String", "message", "lmao");
+
+    await mock.simulateCommand();
+
+    mock.expectRepliedWith({
+      content: "`lmao` does not point to a valid message!",
+      ephemeral: true,
+    });
+  });
+});

--- a/tests/controllers/dev/send.command.test.ts
+++ b/tests/controllers/dev/send.command.test.ts
@@ -1,0 +1,68 @@
+import { GuildTextBasedChannel } from "discord.js";
+import config from "../../../src/config";
+import devSendSpec from "../../../src/controllers/dev/send.command";
+import { RoleLevel } from "../../../src/middleware/privilege.middleware";
+import { MockInteraction } from "../../test-utils";
+
+let mock: MockInteraction;
+beforeEach(() => { mock = new MockInteraction(devSendSpec); });
+
+it("should require privilege level >= DEV", async () => {
+  mock
+    .mockCaller({ roleIds: [config.KAI_RID] })
+    .mockOption("String", "content", "please let me use this");
+  await mock.simulateCommand();
+  expect(mock.interaction.channel!.send).not.toHaveBeenCalled();
+  mock.expectMentionedMissingPrivilege(RoleLevel.DEV);
+});
+
+it("should forward content to current channel", async () => {
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "content", "hello there");
+  await mock.simulateCommand();
+  expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
+    expect.objectContaining({ content: "hello there" }),
+  );
+  mock.expectRepliedGenericACK();
+});
+
+it("should forward content to specified channel", async () => {
+  const mockChannel = { send: jest.fn() } as unknown as GuildTextBasedChannel;
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "content", "general kenobi")
+    .mockOption<GuildTextBasedChannel>("Channel", "channel", mockChannel);
+  await mock.simulateCommand();
+  expect(mockChannel.send).toHaveBeenCalledWith(
+    expect.objectContaining({ content: "general kenobi" }),
+  );
+  mock.expectRepliedGenericACK();
+});
+
+it("should disable mentions by default", async () => {
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "content", "you are a bold one");
+  await mock.simulateCommand();
+  expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
+    expect.objectContaining({
+      allowedMentions: expect.objectContaining({ parse: [] }),
+    }),
+  );
+  mock.expectRepliedGenericACK();
+});
+
+it("should enable mentions if explicitly specified", async () => {
+  mock
+    .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+    .mockOption("String", "content", "you're shorter than i expected")
+    .mockOption("Boolean", "enable_mentions", true);
+  await mock.simulateCommand();
+  expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
+    expect.not.objectContaining({
+      allowedMentions: expect.anything(),
+    }),
+  );
+  mock.expectRepliedGenericACK();
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -20,6 +20,7 @@ import { fromZodError } from "zod-validation-error";
 
 import { CommandRunner } from "../src/bot/command.runner";
 import { ListenerRunner } from "../src/bot/listener.runner";
+import { RoleLevel } from "../src/middleware/privilege.middleware";
 import { ClientWithIntentsAndRunnersABC } from "../src/types/client.abc";
 import { CommandSpec } from "../src/types/command.types";
 import { ListenerSpec } from "../src/types/listener.types";
@@ -153,6 +154,23 @@ export class MockInteraction {
   /**
    * ASSERT.
    *
+   * Expect that the interaction has been replied to with a message mentioning
+   * that the caller is missing privilege.
+   */
+  public expectMentionedMissingPrivilege(level: RoleLevel): void {
+    expect(this.interaction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(
+          `required privilege level: \`${RoleLevel[level]}\``,
+        ),
+        ephemeral: true,
+      }),
+    );
+  }
+
+  /**
+   * ASSERT.
+   *
    * Shorthand for expecting that the interaction has been replied to in any
    * way.
    */
@@ -169,6 +187,19 @@ export class MockInteraction {
   public expectRepliedWith(options: InteractionReplyOptions): void {
     expect(this.interaction.reply).toHaveBeenLastCalledWith(
       expect.objectContaining(options),
+    );
+    expect(this.interaction.reply).toHaveBeenCalledTimes(1);
+  }
+
+  /**
+   * ASSERT.
+   *
+   * Shorthand for expecting that the interaction has been replied to with a
+   * generic acknowledgement.
+   */
+  public expectRepliedGenericACK(): void {
+    expect(this.interaction.reply).toHaveBeenLastCalledWith(
+      expect.objectContaining({ content: "👍", ephemeral: true }),
     );
     expect(this.interaction.reply).toHaveBeenCalledTimes(1);
   }


### PR DESCRIPTION
## Feature

Added some commands to make the bot send arbitrary messages and react arbitrarily, invisibly controlling it to appear like a user.

* `/send [content] [channel]? [enable_mentions]?`, where `enable_mentions` toggles the default behavior of suppressing mention pinging.
* `/react [emoji] [message]?`, where `message` is either a message ID or URL.