### PR TITLE
Add missing await in /set-meow-chance

### DIFF
--- a/src/bot/command.runner.ts
+++ b/src/bot/command.runner.ts
@@ -49,7 +49,13 @@ export class CommandRunner {
         `${context}: execute didn't reply to interaction, ` +
         "using generic response.",
       );
-      await interaction.reply({ content: "👍", ephemeral: true });
+      try {
+        await interaction.reply({ content: "👍", ephemeral: true });
+      }
+      catch (error) {
+        log.error(`${context}: failed to send generic response.`);
+        console.error(error);
+      }
     }
 
     log.debug(`${context}: finished executing command.`);

--- a/src/controllers/users/luke/set-meow-chance.command.ts
+++ b/src/controllers/users/luke/set-meow-chance.command.ts
@@ -38,7 +38,7 @@ setMeowChance.execute(async (interaction) => {
   const context = formatContext(interaction);
   log.info(`${context}: set Luke meow chance to ${newProbability}.`);
 
-  interaction.reply(
+  await interaction.reply(
     `Updated Luke meow chance from ${oldProbability} to ${newProbability}.`,
   );
 });


### PR DESCRIPTION
**EMERGENCY FIX.**

It was bringing down the entire bot. The missing await meant the interaction was not guaranteed to be replied to before the command runner queries the `replied` status. The command runner thus sometimes sees that the interaction had not been replied to and uses the generic response, only for the original reply to take effect and cause an unknown interaction error. I could've sworn I fixed this bug a long time ago, but I guess it was on a branch that never ended up getting merged.

This bug also highlighted a broader issue, which was that the `CommandRunner#run` had a site unguarded by `try`-`catch`, meaning the bot could go down altogether as long as sending the generic response errors for some reason. Thus, this PR also wraps the `interaction.reply()` for the generic acknowledgement with `try`-`catch` to prevent abrupt termination like this in the future.