### PR TITLE
Stop sending message if reference is invalid

### DIFF
--- a/src/controllers/dev/control/send.command.ts
+++ b/src/controllers/dev/control/send.command.ts
@@ -51,6 +51,8 @@ devSend.execute(async interaction => {
   const enableMentions = !!interaction.options.getBoolean("enable_mentions");
 
   const reference = await resolveMessageToReplyTo(interaction);
+  // resolveMessageToReplyTo already replies about error.
+  if (reference === "invalid message") return false;
   const channel = resolveChannelToSendTo(interaction, reference);
 
   await channel.send({
@@ -61,24 +63,43 @@ devSend.execute(async interaction => {
   });
 
   await interaction.reply({ content: "👍", ephemeral: true });
+  return true;
 });
 
+/**
+ * - Return a `Message` object representing the message to reply to if a
+ *   reference is provided and is valid.
+ * - Return `null` if no reference is provided, so the bot's message shouldn't
+ *   reply to anything.
+ * - Return `"invalid message"` if a reference is provided but is invalid, so
+ *   the bot should reject the command and show an error to the caller.
+ */
 async function resolveMessageToReplyTo(
   interaction: ChatInputCommandInteraction,
-): Promise<Message | null> {
+): Promise<Message | null | "invalid message"> {
   const referenceIdentifier = interaction.options.getString("reference");
   if (referenceIdentifier === "^") {
     return await fetchMostRecentMessage(interaction);
   }
   if (referenceIdentifier) {
-    return await fetchMessageByIdentifier(
+    const message = await fetchMessageByIdentifier(
       referenceIdentifier,
       interaction,
     );
+    if (message === null) return "invalid message";
+    return message;
   }
   return null;
 }
 
+/**
+ * Return the text channel the bot should ultimately send the message to.
+ *
+ * - If a valid reference was provided, use the channel of the referenced
+ *   message.
+ * - Else use the channel provided in the `channel` option.
+ * - Else use the channel the command was invoked in.
+ */
 function resolveChannelToSendTo(
   interaction: ChatInputCommandInteraction,
   reference: Message | null,

--- a/tests/controllers/dev/control/send.command.test.ts
+++ b/tests/controllers/dev/control/send.command.test.ts
@@ -1,6 +1,6 @@
 import { GuildTextBasedChannel, Message } from "discord.js";
-
 import { DeepMockProxy } from "jest-mock-extended";
+
 import config from "../../../../src/config";
 import devSendSpec from "../../../../src/controllers/dev/control/send.command";
 import { RoleLevel } from "../../../../src/middleware/privilege.middleware";
@@ -126,5 +126,19 @@ describe("replying to another message", () => {
 
     expectRepliedWithReference(mockMessage, "i have the high ground");
     mock.expectRepliedGenericACK();
+  });
+
+  it("should reject invalid message identifiers", async () => {
+    mock
+      .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+      .mockOption("String", "content", "you underestimate my power")
+      .mockOption("String", "reference", "don't try it");
+
+    await mock.simulateCommand();
+
+    mock.expectRepliedWith({
+      content: "`don't try it` does not point to a valid message!",
+      ephemeral: true,
+    });
   });
 });


### PR DESCRIPTION
Fix to the `reference` (reply) enhancement introduced in #91 to the `/send` command introduced in #89 .

Before, the bot would reply with error to the interaction (expectedly), but then execution would fall through to make the bot send a message to the channel anyway and finishing with the generic ACK, causing an `InteractionAlreadyReplied` error.