### PR TITLE
Rate limit mentioning the same user

### DIFF
--- a/src/controllers/moderation/mention-spam.listener.ts
+++ b/src/controllers/moderation/mention-spam.listener.ts
@@ -1,9 +1,14 @@
-import { EmbedBuilder, GuildMember, Message, userMention } from "discord.js";
+import {
+  EmbedBuilder,
+  GuildMember,
+  Message,
+  MessageFlags,
+  userMention,
+} from "discord.js";
 
 import getLogger from "../../logger";
 import mentionSpamService from "../../services/mention-spam.service";
 import { MessageListenerBuilder } from "../../types/listener.types";
-import { replySilently } from "../../utils/interaction.utils";
 import { formatContext } from "../../utils/logging.utils";
 
 const log = getLogger(__filename);
@@ -31,7 +36,11 @@ async function timeOutAuthorForMentionSpammingTarget(
   const embed = new EmbedBuilder()
     .setDescription(`Stop spam mentioning ${userMention(target.id)}.`);
   try {
-    await replySilently(message, { embeds: [embed] });
+    await message.reply({
+      embeds: [embed],
+      // Reply with @silent but reply ping ON.
+      flags: MessageFlags.SuppressNotifications,
+    });
   }
   catch {
     log.warning(`failed to reply to ${message.url}.`);

--- a/src/controllers/moderation/mention-spam.listener.ts
+++ b/src/controllers/moderation/mention-spam.listener.ts
@@ -36,7 +36,10 @@ async function timeOutAuthorForMentionSpammingTarget(
   catch {
     log.warning(`failed to reply to ${message.url}.`);
   }
-  await author.timeout(60_000, `Spamming mention @${target.user.username}.`);
+
+  const mention = userMention(target.id);
+  const reason = `Spam mentioning ${mention} (\`@${target.user.username}\`).`;
+  await author.timeout(60_000, reason);
 
   const context = formatContext(message);
   log.info(

--- a/src/controllers/moderation/mention-spam.listener.ts
+++ b/src/controllers/moderation/mention-spam.listener.ts
@@ -1,0 +1,49 @@
+import { EmbedBuilder, GuildMember, Message, userMention } from "discord.js";
+
+import getLogger from "../../logger";
+import mentionSpamService from "../../services/mention-spam.service";
+import { MessageListenerBuilder } from "../../types/listener.types";
+import { replySilently } from "../../utils/interaction.utils";
+import { formatContext } from "../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+const mentionSpam = new MessageListenerBuilder().setId("mention-spam");
+
+mentionSpam.execute(async message => {
+  const { mentions, member } = message;
+  const mentionedMembers = mentions.members!.values();
+  for (const target of mentionedMembers) {
+    const withinRateLimit = mentionSpamService.mentioned(member!.id, target.id);
+    if (!withinRateLimit) {
+      await timeOutAuthorForMentionSpammingTarget(message, member!, target);
+      return true;
+    }
+  }
+  return false;
+});
+
+async function timeOutAuthorForMentionSpammingTarget(
+  message: Message,
+  author: GuildMember,
+  target: GuildMember,
+): Promise<void> {
+  const embed = new EmbedBuilder()
+    .setDescription(`Stop spam mentioning ${userMention(target.id)}.`);
+  try {
+    await replySilently(message, { embeds: [embed] });
+  }
+  catch {
+    log.warning(`failed to reply to ${message.url}.`);
+  }
+  await author.timeout(60_000, `Spamming mention @${target.user.username}.`);
+
+  const context = formatContext(message);
+  log.info(
+    `${context}: timed out @${author.user.username} for spam mentioning ` +
+    `@${target.user.username}.`,
+  );
+}
+
+const mentionSpamSpec = mentionSpam.toSpec();
+export default mentionSpamSpec;

--- a/src/services/mention-spam.service.ts
+++ b/src/services/mention-spam.service.ts
@@ -1,30 +1,6 @@
 import { Collection } from "discord.js";
-import { TokenBucket } from "../utils/algorithms.utils";
 
-// TODO: Move this to a helper file?
-class PerIDSpamTracker<
-  Rate extends number,
-  Capacity extends number,
-> {
-  protected buckets = new Collection<string, TokenBucket<Rate, Capacity>>();
-  constructor(
-    protected readonly rate: Rate,
-    protected readonly capacity: Capacity,
-  ) { }
-
-  /**
-   * Consume a token for the rate limiter for some event for the given ID.
-   * Return whether the event is still within the rate limit.
-   */
-  public reportEvent(id: string): boolean {
-    let bucket = this.buckets.get(id);
-    if (!bucket) {
-      bucket = new TokenBucket(this.rate, this.capacity);
-      this.buckets.set(id, bucket);
-    }
-    return bucket.consume();
-  }
-}
+import { PerIDSpamTracker } from "../utils/algorithms.utils";
 
 export class MentionSpamService {
   private spamTrackers = new Collection<string, PerIDSpamTracker<0.1, 3>>();

--- a/src/services/mention-spam.service.ts
+++ b/src/services/mention-spam.service.ts
@@ -1,0 +1,46 @@
+import { Collection } from "discord.js";
+import { TokenBucket } from "../utils/algorithms.utils";
+
+// TODO: Move this to a helper file?
+class PerIDSpamTracker<
+  Rate extends number,
+  Capacity extends number,
+> {
+  protected buckets = new Collection<string, TokenBucket<Rate, Capacity>>();
+  constructor(
+    protected readonly rate: Rate,
+    protected readonly capacity: Capacity,
+  ) { }
+
+  /**
+   * Consume a token for the rate limiter for some event for the given ID.
+   * Return whether the event is still within the rate limit.
+   */
+  public reportEvent(id: string): boolean {
+    let bucket = this.buckets.get(id);
+    if (!bucket) {
+      bucket = new TokenBucket(this.rate, this.capacity);
+      this.buckets.set(id, bucket);
+    }
+    return bucket.consume();
+  }
+}
+
+export class MentionSpamService {
+  private spamTrackers = new Collection<string, PerIDSpamTracker<0.1, 3>>();
+
+  /**
+   * Report a mention event. Return whether this event is still within the rate
+   * limit.
+   */
+  public mentioned(mentionerId: string, mentionedId: string): boolean {
+    let tracker = this.spamTrackers.get(mentionerId);
+    if (!tracker) {
+      tracker = new PerIDSpamTracker(0.1, 3);
+      this.spamTrackers.set(mentionerId, tracker);
+    }
+    return tracker.reportEvent(mentionedId);
+  }
+}
+
+export default new MentionSpamService();

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -4,6 +4,7 @@ import {
   Events,
   GuildMember,
   Message,
+  MessageCreateOptions,
   MessageFlags,
 } from "discord.js";
 
@@ -17,12 +18,17 @@ const log = getLogger(__filename);
  * Wrapper for the boilerplate of replying to a `Message` with the `@silent`
  * setting and without pinging anyone.
  */
-export async function replySilently(message: Message, content: string) {
-  await message.reply({
-    content,
+export async function replySilently(
+  message: Message,
+  content: string | MessageCreateOptions,
+) {
+  let payload = typeof content === "string" ? { content } : content;
+  payload = {
+    ...payload,
     allowedMentions: { repliedUser: false, parse: [] },
     flags: MessageFlags.SuppressNotifications,
-  });
+  };
+  await message.reply(payload);
 }
 
 /**

--- a/tests/controllers/moderation/mention-spam.listener.test.ts
+++ b/tests/controllers/moderation/mention-spam.listener.test.ts
@@ -55,8 +55,8 @@ function mockRateLimited(...members: GuildMember[]): void {
 
 function expectAuthorTimedOut(): void {
   expect(mock.message.member!.timeout).toHaveBeenCalledWith(
-    expect.any(Number),
-    expect.any(String),
+    expect.any(Number), // Duration.
+    expect.any(String), // Reason.
   );
 }
 

--- a/tests/controllers/moderation/mention-spam.listener.test.ts
+++ b/tests/controllers/moderation/mention-spam.listener.test.ts
@@ -1,0 +1,124 @@
+jest.mock("../../../src/services/mention-spam.service");
+
+import {
+  EmbedBuilder,
+  GuildMember,
+  MessageFlags,
+  userMention,
+} from "discord.js";
+
+import { Matcher } from "jest-mock-extended";
+import mentionSpamSpec from "../../../src/controllers/moderation/mention-spam.listener";
+import mentionSpamService from "../../../src/services/mention-spam.service";
+import { MockMessage } from "../../test-utils";
+
+const mockedMentionSpamService = jest.mocked(mentionSpamService);
+
+let mock: MockMessage;
+
+const dummyAuthorId = "DUMMY-AUTHOR";
+
+const mockTarget1 = {
+  id: "DUMMY-TARGET-1",
+  timeout: jest.fn(),
+  user: {
+    username: "dummytarget1",
+  },
+} as unknown as GuildMember;
+
+const mockTarget2 = {
+  id: "DUMMY-TARGET-2",
+  timeout: jest.fn(),
+  user: {
+    username: "dummytarget2",
+  },
+} as unknown as GuildMember;
+
+beforeEach(() => {
+  jest.resetAllMocks(); // TODO: Automate this with resetMocks config.
+  mock = new MockMessage(mentionSpamSpec).mockAuthor({ uid: dummyAuthorId });
+  // Default to true. Took too long fixing a bug where I needed to explicitly
+  // mock the return value or a falsy undefined would have been used.
+  mockedMentionSpamService.mentioned.mockReturnValue(true);
+});
+
+function mockMemberMentions(...members: GuildMember[]): void {
+  mock.message.mentions.members!.values.mockReturnValue(members.values());
+}
+
+function mockRateLimited(...members: GuildMember[]): void {
+  const uids = members.map(member => member.id);
+  mockedMentionSpamService.mentioned.mockImplementation(
+    (_, mentionedId) => !uids.includes(mentionedId),
+  );
+}
+
+function expectAuthorTimedOut(): void {
+  expect(mock.message.member!.timeout).toHaveBeenCalledWith(
+    expect.any(Number),
+    expect.any(String),
+  );
+}
+
+it("should call service for each mention in the message", async () => {
+  mockMemberMentions(mockTarget1, mockTarget2);
+
+  await mock.simulateEvent();
+
+  expect(mockedMentionSpamService.mentioned)
+    .toHaveBeenCalledWith(dummyAuthorId, mockTarget1.id);
+  expect(mockedMentionSpamService.mentioned)
+    .toHaveBeenCalledWith(dummyAuthorId, mockTarget2.id);
+});
+
+it("should time out author for mention spamming", async () => {
+  mockMemberMentions(mockTarget1);
+  mockRateLimited(mockTarget1);
+
+  await mock.simulateEvent();
+
+  expectAuthorTimedOut();
+});
+
+it("should not time out author if within rate limit", async () => {
+  mockMemberMentions(mockTarget1);
+
+  await mock.simulateEvent();
+
+  expect(mock.message.member!.timeout).not.toHaveBeenCalled();
+});
+
+it("should reply to offending message with embed", async () => {
+  mockMemberMentions(mockTarget1);
+  mockRateLimited(mockTarget1);
+
+  await mock.simulateEvent();
+
+  const embedMatcher = new Matcher<EmbedBuilder>(embed => {
+    const mention = userMention(mockTarget1.id);
+    return embed.data.description === `Stop spam mentioning ${mention}.`;
+  }, "embed matcher");
+  expect(mock.message.reply).toHaveBeenCalledWith(expect.objectContaining({
+    embeds: [embedMatcher],
+    flags: MessageFlags.SuppressNotifications,
+  }));
+});
+
+it("should count mentions for different targets independently", async () => {
+  mockMemberMentions(mockTarget1, mockTarget2);
+  mockRateLimited(mockTarget2);
+
+  await mock.simulateEvent();
+
+  expectAuthorTimedOut();
+});
+
+it("should still time out if embed sending fails", async () => {
+  mockMemberMentions(mockTarget1);
+  mockRateLimited(mockTarget1);
+  mock.message.reply.mockRejectedValueOnce("DUMMY-ERROR");
+
+  await mock.simulateEvent();
+
+  expectAuthorTimedOut();
+});

--- a/tests/controllers/moderation/mention-spam.listener.test.ts
+++ b/tests/controllers/moderation/mention-spam.listener.test.ts
@@ -60,6 +60,10 @@ function expectAuthorTimedOut(): void {
   );
 }
 
+function expectAuthorNotTimedOut(): void {
+  expect(mock.message.member!.timeout).not.toHaveBeenCalled();
+}
+
 it("should call service for each mention in the message", async () => {
   mockMemberMentions(mockTarget1, mockTarget2);
 
@@ -85,7 +89,7 @@ it("should not time out author if within rate limit", async () => {
 
   await mock.simulateEvent();
 
-  expect(mock.message.member!.timeout).not.toHaveBeenCalled();
+  expectAuthorNotTimedOut();
 });
 
 it("should reply to offending message with embed", async () => {

--- a/tests/services/mention-spam.service.test.ts
+++ b/tests/services/mention-spam.service.test.ts
@@ -1,0 +1,39 @@
+import { MentionSpamService } from "../../src/services/mention-spam.service";
+import { PerIDSpamTracker } from "../../src/utils/algorithms.utils";
+
+const mentioner = "123456789";
+const mentioned1 = "987654321";
+const mentioned2 = "424242420";
+
+let mentionSpamService: MentionSpamService;
+let trackerSpy: jest.SpyInstance<boolean, [id: string]>;
+beforeEach(() => {
+  mentionSpamService = new MentionSpamService();
+  trackerSpy = jest.spyOn(PerIDSpamTracker.prototype, "reportEvent");
+});
+
+it("should report an event upon mention", async () => {
+  mentionSpamService.mentioned(mentioner, mentioned1);
+  expect(trackerSpy).toHaveBeenCalled();
+});
+
+it("should return true if mentioner is within rate limit", async () => {
+  trackerSpy.mockReturnValueOnce(true);
+  const result = mentionSpamService.mentioned(mentioner, mentioned1);
+  expect(result).toEqual(true);
+});
+
+it("should return false if mentioner exceeds rate limit", async () => {
+  trackerSpy.mockReturnValueOnce(false);
+  const result = mentionSpamService.mentioned(mentioner, mentioned1);
+  expect(result).toEqual(false);
+});
+
+it("should count mentions to different users independently", async () => {
+  // Reach the rate limit mentioning dummy target 1.
+  for (let i = 0; i < 3; i++) {
+    mentionSpamService.mentioned(mentioner, mentioned1);
+  }
+  expect(mentionSpamService.mentioned(mentioner, mentioned1)).toEqual(false);
+  expect(mentionSpamService.mentioned(mentioner, mentioned2)).toEqual(true);
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -350,6 +350,7 @@ export class MockMessage {
   public mockAuthor(options: MockAuthorOptions): this {
     if (options.uid !== undefined) {
       this.message.author.id = options.uid;
+      addMockGetter(this.message.member!, "id", options.uid);
     }
     if (options.displayName !== undefined) {
       addMockGetter(this.message.author, "displayName", options.displayName);


### PR DESCRIPTION
## Feature

The bot now rate limits mentions on a per-mentioner, per-mentioned basis. That is, if a user mentions the **same** user too many times within a short time, the bot will time that user out for 60 seconds.

This feature uses the **token bucket algorithm**, same as the timeout rate-limiting feature (#84). Starting parameters: `rate=0.1`, `capacity=3`. That is, each user can mention the same user up to 3 times in quick succession, and they regain one "allowance" every 10 seconds to be able to mention that same user again.

**NOTE:** Mentioning _separate_ users in quick succession (or in the same message) does not count towards this rate limiting (although it will towards Discord's built-in mention spam protection). Furthermore, the rate limiting counts the number of distinct _pings_, not mention strings, so mentioning the same person many times in one message only counts as one ping.

### Motivation

As mentioned above, Discord has a built-in mechanism to prevent and punish mass mentions, but they do so by counting mentions to distinct users. In other words, it protects against the case counterpart to ours:

* Discord protects against pinging many people at once.
* Our new feature protects against pinging the _same_ person many times over.

To my knowledge, there's no way to prevent repetitive pinging of any one user on the Discord side, and I can't be bothered to search up existing bots for this feature. Thus, to TempBot it goes.

## Other Changes

* Added a `MessageCreateOptions` overload to `replySilently`.
* Added `PerIDSpamTracker` to abstract the handling of per-user `TokenBucket`s. Also updated the existing `TimeoutService` introduced in #73 to use this helper class.
