### PR TITLE
Add tests for CommandRunner

### DIFF
--- a/src/bot/command.errors.ts
+++ b/src/bot/command.errors.ts
@@ -1,0 +1,27 @@
+import { InteractionReplyOptions } from "discord.js";
+
+import { DiscordAPIErrorWithCode } from "../types/errors.types";
+
+/**
+ * Type for functions returning the options to use when replying to/following up
+ * with the interaction upon a specific type of command error.
+ *
+ * If the `Opcode` type parameter is left as `null`, the error argument is left
+ * as a general `Error` type. Otherwise, the `Opcode` specifies the type of
+ * Discord API error.
+ */
+export type ErrorReplyGetter<Opcode extends number | null = null>
+  = (error?: Opcode extends number ? DiscordAPIErrorWithCode<Opcode> : Error)
+    => Omit<InteractionReplyOptions, "ephemeral">;
+
+export const getReplyForUnknownError: ErrorReplyGetter = () => {
+  return {
+    content: "There was an error while executing this command!",
+  };
+};
+
+export const getReplyForMissingPermissions: ErrorReplyGetter<50013> = () => {
+  return {
+    content: "I'm not allowed to perform this action!",
+  };
+};

--- a/tests/bot/command.runner.test.ts
+++ b/tests/bot/command.runner.test.ts
@@ -1,0 +1,70 @@
+jest.mock("../../src/utils/logging.utils");
+
+import {
+  ChatInputCommandInteraction,
+  InteractionReplyOptions,
+  RESTPostAPIChatInputApplicationCommandsJSONBody,
+} from "discord.js";
+import { CommandRunner } from "../../src/bot/command.runner";
+import { CommandSpec } from "../../src/types/command.types";
+import { suppressConsoleError } from "../test-utils";
+
+function getCommandInteraction(options?: {
+  replied?: boolean,
+  deferred?: boolean,
+}): ChatInputCommandInteraction {
+  return {
+    replied: !!options?.replied,
+    deferred: !!options?.deferred,
+    reply: jest.fn(),
+    followUp: jest.fn(),
+  } as unknown as ChatInputCommandInteraction;
+}
+
+beforeEach(suppressConsoleError);
+
+describe("run", () => {
+  const spec: CommandSpec = {
+    definition: {} as RESTPostAPIChatInputApplicationCommandsJSONBody,
+    execute: jest.fn(),
+  };
+
+  let runner: CommandRunner;
+  beforeEach(() => runner = new CommandRunner(spec));
+
+  it("should run the execute callback", async () => {
+    const interaction = getCommandInteraction();
+    await runner.run(interaction);
+    expect(spec.execute).toHaveBeenCalledWith(interaction);
+  });
+
+  describe("error handling", () => {
+    beforeEach(() => {
+      jest.mocked(spec.execute).mockRejectedValueOnce(new Error("DUMMY-ERROR"));
+    });
+
+    function expectCalledWithErrorReply(func: any): void {
+      expect(func).toHaveBeenCalledWith(
+        expect.objectContaining<InteractionReplyOptions>({ ephemeral: true }),
+      );
+    }
+
+    it("should reply with error if callback errors", async () => {
+      const interaction = getCommandInteraction();
+      await runner.run(interaction);
+      expectCalledWithErrorReply(interaction.reply);
+    });
+
+    it("should follow up with error if already replied", async () => {
+      const interaction = getCommandInteraction({ replied: true });
+      await runner.run(interaction);
+      expectCalledWithErrorReply(interaction.followUp);
+    });
+
+    it("should follow up with error if deferred", async () => {
+      const interaction = getCommandInteraction({ deferred: true });
+      await runner.run(interaction);
+      expectCalledWithErrorReply(interaction.followUp);
+    });
+  });
+});

--- a/tests/bot/command.runner.test.ts
+++ b/tests/bot/command.runner.test.ts
@@ -101,3 +101,19 @@ describe("resolveAutocomplete", () => {
     expect(spec.execute).not.toHaveBeenCalled();
   });
 });
+
+describe("getDeployJSON", () => {
+  it("should return the spec's definition", () => {
+    const spec: CommandSpec = {
+      definition: {
+        name: "dummy-command-name",
+      } as RESTPostAPIChatInputApplicationCommandsJSONBody,
+      execute: jest.fn(),
+    };
+    const runner = new CommandRunner(spec);
+
+    const result = runner.getDeployJSON();
+
+    expect(result).toEqual(spec.definition);
+  });
+});

--- a/tests/bot/command.runner.test.ts
+++ b/tests/bot/command.runner.test.ts
@@ -1,6 +1,7 @@
 jest.mock("../../src/utils/logging.utils");
 
 import {
+  AutocompleteInteraction,
   ChatInputCommandInteraction,
   InteractionReplyOptions,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
@@ -66,5 +67,37 @@ describe("run", () => {
       await runner.run(interaction);
       expectCalledWithErrorReply(interaction.followUp);
     });
+  });
+});
+
+describe("resolveAutocomplete", () => {
+  const autocompleteInteraction = {} as AutocompleteInteraction;
+
+  it("should call just the autocomplete callback", async () => {
+    const spec: CommandSpec = {
+      definition: {} as RESTPostAPIChatInputApplicationCommandsJSONBody,
+      execute: jest.fn(),
+      autocomplete: jest.fn(),
+      checks: [{ predicate: jest.fn() }],
+    };
+    const runner = new CommandRunner(spec);
+
+    await runner.resolveAutocomplete(autocompleteInteraction);
+
+    expect(spec.autocomplete).toHaveBeenCalledWith(autocompleteInteraction);
+    expect(spec.execute).not.toHaveBeenCalled();
+    expect(spec.checks![0].predicate).not.toHaveBeenCalled();
+  });
+
+  it("should do nothing if no autocomplete callback provided", async () => {
+    const spec: CommandSpec = {
+      definition: {} as RESTPostAPIChatInputApplicationCommandsJSONBody,
+      execute: jest.fn(),
+    };
+    const runner = new CommandRunner(spec);
+
+    await runner.resolveAutocomplete(autocompleteInteraction);
+
+    expect(spec.execute).not.toHaveBeenCalled();
   });
 });

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -571,3 +571,7 @@ export function expectMatchingSchema(
 export function spyOnRandom(): jest.SpyInstance {
   return jest.spyOn(global.Math, "random");
 }
+
+export function suppressConsoleError(): void {
+  jest.spyOn(console, "error").mockImplementation(() => { });
+}


### PR DESCRIPTION
## Main Changes

Added long-awaited tests for the `CommandRunner` class, which much of existing test suite had already been depending on.

## Other Changes

* Introduced `bot/command.errors.ts` to declaratively define how to reply to interactions upon specific `DiscordAPIError`s. Started off with specially handling **Missing Permissions** (50013).
* Added a `suppressConsoleError` helper to `test-utils.ts` as a shorthand for suppressing `console.error`.