### PR TITLE
Implement ^.../^N notation for /send and /react

### DIFF
--- a/src/controllers/dev/control/dev-control-utils.ts
+++ b/src/controllers/dev/control/dev-control-utils.ts
@@ -1,11 +1,15 @@
 import { ChatInputCommandInteraction, Message } from "discord.js";
+import { sortBy } from "lodash";
 
-export async function fetchMostRecentMessage(
+export async function fetchNthMostRecentMessage(
   interaction: ChatInputCommandInteraction,
-): Promise<Message> {
-  const messages = await interaction.channel!.messages.fetch({ limit: 1 });
-  const message = Array.from(messages.values())[0];
-  return message;
+  n: number,
+): Promise<Message | null> {
+  const collection = await interaction.channel!.messages.fetch({ limit: n });
+  const messages = Array.from(collection.values());
+  const sortedMessages = sortBy(messages, m => m.createdTimestamp);
+  const nthRecentMessage = sortedMessages.at(0);
+  return nthRecentMessage ?? null;
 }
 
 export function extractMessageID(idOrUrl: string): string | null {

--- a/src/controllers/dev/control/react.command.ts
+++ b/src/controllers/dev/control/react.command.ts
@@ -7,7 +7,7 @@ import {
 import { CommandBuilder } from "../../../types/command.types";
 import {
   fetchMessageByIdentifier,
-  fetchMostRecentMessage,
+  fetchNthMostRecentMessage,
 } from "./dev-control-utils";
 
 const devReact = new CommandBuilder();
@@ -36,7 +36,7 @@ devReact.execute(async interaction => {
 
   const message = messageIdentifier
     ? await fetchMessageByIdentifier(messageIdentifier, interaction)
-    : await fetchMostRecentMessage(interaction);
+    : await fetchNthMostRecentMessage(interaction, 1);
   if (!message) return false;
 
   try {

--- a/src/controllers/dev/control/send.command.ts
+++ b/src/controllers/dev/control/send.command.ts
@@ -35,20 +35,20 @@ devSend.define(new SlashCommandBuilder()
   .addStringOption(input => input
     .setName("reference")
     .setDescription(
-      "ID or URL of message to reply to. \"^\" for last message. " +
+      "ID or URL of message to reply to. ^ for last message. " +
       "Overrides channel option if applicable.",
     ),
   )
   .addBooleanOption(input => input
-    .setName("enable_mentions")
-    .setDescription("Whether mentions should ping the user."),
+    .setName("silent")
+    .setDescription("Whether to suppress notifications and mentions."),
   ),
 );
 
 devSend.check(checkPrivilege(RoleLevel.DEV));
 devSend.execute(async interaction => {
   const content = interaction.options.getString("content", true);
-  const enableMentions = !!interaction.options.getBoolean("enable_mentions");
+  const silent = !!interaction.options.getBoolean("silent");
 
   const reference = await resolveMessageToReplyTo(interaction);
   // resolveMessageToReplyTo already replies about error.
@@ -57,8 +57,8 @@ devSend.execute(async interaction => {
 
   await channel.send({
     content,
-    allowedMentions: enableMentions ? undefined : { parse: [] },
-    flags: MessageFlags.SuppressNotifications,
+    allowedMentions: silent ? { parse: [] } : undefined,
+    flags: silent ? MessageFlags.SuppressNotifications : undefined,
     reply: reference ? { messageReference: reference } : undefined,
   });
 

--- a/tests/controllers/dev/control/dev-control-test-utils.ts
+++ b/tests/controllers/dev/control/dev-control-test-utils.ts
@@ -20,9 +20,20 @@ export function mockChannelFetchMessageById(
 
 export function mockChannelFetchMessage(
   mock: MockInteraction,
+  nthMostRecent: number = 1,
 ): DeepMockProxy<Message<true>> {
-  const mockMessage = mockDeep<Message<true>>();
-  mock.interaction.channel!.messages.fetch
-    .mockResolvedValueOnce(new Collection([["DUMMY-ID", mockMessage]]));
+  // mockMessages is in ascending order of timestamp.
+  const mockMessages = Array.from({ length: nthMostRecent }).map((_, i) => {
+    const message = mockDeep<Message<true>>();
+    message.createdTimestamp = new Date(i * 1000).getTime();
+    return message;
+  });
+
+  const asIdMessagePairs = mockMessages
+    .map((message, i) => [`DUMMY-ID-${i}`, message] as const);
+  const asCollection = new Collection(asIdMessagePairs);
+  mock.interaction.channel!.messages.fetch.mockResolvedValueOnce(asCollection);
+
+  const mockMessage = mockMessages[0];
   return mockMessage;
 }

--- a/tests/controllers/dev/control/react.command.test.ts
+++ b/tests/controllers/dev/control/react.command.test.ts
@@ -65,6 +65,34 @@ it("should react to the specified message (using URL)", async () => {
   mock.expectRepliedGenericACK();
 });
 
+describe("caret notation", () => {
+  beforeEach(() => {
+    mock
+      .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+      .mockOption("String", "emoji", "🔥");
+  });
+
+  it("should react to the 3rd most recent message (by ^^^)", async () => {
+    mock.mockOption("String", "message", "^^^");
+    const mockMessage = mockChannelFetchMessage(mock, 3);
+
+    await mock.simulateCommand();
+
+    expect(mockMessage.react).toHaveBeenCalledWith("🔥");
+    mock.expectRepliedGenericACK();
+  });
+
+  it("should react to the 3rd most recent message (by ^3)", async () => {
+    mock.mockOption("String", "message", "^3");
+    const mockMessage = mockChannelFetchMessage(mock, 3);
+
+    await mock.simulateCommand();
+
+    expect(mockMessage.react).toHaveBeenCalledWith("🔥");
+    mock.expectRepliedGenericACK();
+  });
+});
+
 describe("error handling", () => {
   it("should reject invalid emojis", async () => {
     mock

--- a/tests/controllers/dev/control/send.command.test.ts
+++ b/tests/controllers/dev/control/send.command.test.ts
@@ -1,4 +1,4 @@
-import { GuildTextBasedChannel, Message } from "discord.js";
+import { GuildTextBasedChannel, Message, MessageFlags } from "discord.js";
 import { DeepMockProxy } from "jest-mock-extended";
 
 import config from "../../../../src/config";
@@ -46,28 +46,30 @@ it("should forward content to specified channel", async () => {
   mock.expectRepliedGenericACK();
 });
 
-it("should disable mentions by default", async () => {
+it("should enable mentions by default", async () => {
   mock
     .mockCaller({ roleIds: [config.BOT_DEV_RID] })
     .mockOption("String", "content", "you are a bold one");
   await mock.simulateCommand();
   expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
-    expect.objectContaining({
-      allowedMentions: expect.objectContaining({ parse: [] }),
+    expect.not.objectContaining({
+      allowedMentions: expect.anything(),
+      flags: MessageFlags.SuppressNotifications,
     }),
   );
   mock.expectRepliedGenericACK();
 });
 
-it("should enable mentions if explicitly specified", async () => {
+it("should disable mentions if explicitly specified", async () => {
   mock
     .mockCaller({ roleIds: [config.BOT_DEV_RID] })
     .mockOption("String", "content", "you're shorter than i expected")
-    .mockOption("Boolean", "enable_mentions", true);
+    .mockOption("Boolean", "silent", true);
   await mock.simulateCommand();
   expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
-    expect.not.objectContaining({
-      allowedMentions: expect.anything(),
+    expect.objectContaining({
+      allowedMentions: expect.objectContaining({ parse: [] }),
+      flags: MessageFlags.SuppressNotifications,
     }),
   );
   mock.expectRepliedGenericACK();

--- a/tests/controllers/dev/control/send.command.test.ts
+++ b/tests/controllers/dev/control/send.command.test.ts
@@ -117,17 +117,42 @@ describe("replying to another message", () => {
     mock.expectRepliedGenericACK();
   });
 
-  it("should reply to the most recent message in channel", async () => {
-    mock
-      .mockCaller({ roleIds: [config.BOT_DEV_RID] })
-      .mockOption("String", "content", "i have the high ground")
-      .mockOption("String", "reference", "^");
-    const mockMessage = mockChannelFetchMessage(mock);
+  describe("caret notation", () => {
+    beforeEach(() => {
+      mock
+        .mockCaller({ roleIds: [config.BOT_DEV_RID] })
+        .mockOption("String", "content", "i have the high ground");
+    });
 
-    await mock.simulateCommand();
+    it("should reply to the most recent message in channel", async () => {
+      mock.mockOption("String", "reference", "^");
+      const mockMessage = mockChannelFetchMessage(mock);
 
-    expectRepliedWithReference(mockMessage, "i have the high ground");
-    mock.expectRepliedGenericACK();
+      await mock.simulateCommand();
+
+      expectRepliedWithReference(mockMessage, "i have the high ground");
+      mock.expectRepliedGenericACK();
+    });
+
+    it("should reply to the 3rd most recent message (by ^^^)", async () => {
+      mock.mockOption("String", "reference", "^^^");
+      const mockMessage = mockChannelFetchMessage(mock, 3);
+
+      await mock.simulateCommand();
+
+      expectRepliedWithReference(mockMessage, "i have the high ground");
+      mock.expectRepliedGenericACK();
+    });
+
+    it("should reply to the 3rd most recent message (by ^3)", async () => {
+      mock.mockOption("String", "reference", "^3");
+      const mockMessage = mockChannelFetchMessage(mock, 3);
+
+      await mock.simulateCommand();
+
+      expectRepliedWithReference(mockMessage, "i have the high ground");
+      mock.expectRepliedGenericACK();
+    });
   });
 
   it("should reject invalid message identifiers", async () => {

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -32,7 +32,6 @@ export type OptionType =
   | "Integer"
   | "Member"
   | "Mentionable"
-  | "Message"
   | "Number"
   | "Role"
   | "String"
@@ -72,6 +71,29 @@ export class MockInteraction {
     // Override attached client with stub.
     this.client = mockDeep<TestClient>();
     addMockGetter(this.interaction, "client", this.client);
+
+    // Make options by default return null, not undefined, since client code is
+    // likely to explicitly check against null.
+    this.interaction.options.getAttachment.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getBoolean.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getChannel.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getInteger.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getMember.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getMentionable.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getNumber.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getRole.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getString.calledWith(expect.any(String))
+      .mockReturnValue(null);
+    this.interaction.options.getUser.calledWith(expect.any(String))
+      .mockReturnValue(null);
   }
 
   /**


### PR DESCRIPTION
## Feature

The `reference` option for `/send` (and `message` option for `/react`) now supports notation with the caret (`^`) character, inspired by Git reference notation. Examples:

- `^`: Last message. Also equivalent to `^1`.
- `^^^`: Third last message. Also equivalent to `^3`.
- `^5`: Fifth last message.

## Other Changes

- Changed the `enable_mentions` switch to `silent`. "Silent" here refers to the combination of no allowed mentions AND `MessageFlags.SuppressNotifications`.
- Make options in `MockInteraction` by default return `null`, not `undefined` (as occurs when not mocking with anything), since client code is likely to explicitly check against null.