### PR TITLE
Add /timeout-proxy to time out through the bot

### DIFF
--- a/src/controllers/moderation/timeout/timeout-proxy.command.ts
+++ b/src/controllers/moderation/timeout/timeout-proxy.command.ts
@@ -1,0 +1,78 @@
+import {
+  GuildMember,
+  PermissionFlagsBits,
+  SlashCommandBuilder,
+  inlineCode,
+} from "discord.js";
+
+import getLogger from "../../../logger";
+import {
+  RoleLevel,
+  checkPrivilege,
+} from "../../../middleware/privilege.middleware";
+import { CommandBuilder } from "../../../types/command.types";
+import {
+  durationToSeconds,
+  formatHoursMinsSeconds,
+} from "../../../utils/dates.utils";
+import { replyWithGenericACK } from "../../../utils/interaction.utils";
+import { formatContext } from "../../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+const timeoutProxy = new CommandBuilder();
+
+timeoutProxy.define(new SlashCommandBuilder()
+  .setName("timeout-proxy")
+  .setDescription("Issue a timeout through this bot.")
+  // NOTE: What appears as "Timeout Members" in the Discord GUI is the
+  // MODERATE_MEMBERS permission name in the API.
+  .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+  .addUserOption(input => input
+    .setName("user")
+    .setDescription("Member to time out.")
+    .setRequired(true),
+  )
+  .addStringOption(input => input
+    .setName("duration")
+    .setDescription(
+      "Example: \"10 min\". Assumes minutes if units are omitted. " +
+      "Defaults to 1 minute.",
+    ),
+  )
+  .addStringOption(input => input
+    .setName("reason")
+    .setDescription("Reason (to be included in the audit log)."),
+  ),
+);
+
+// In addition, make it so that only Alpha+ can use it. Otherwise, baby mods may
+// be able to abuse this feature to evade the audit log, or something like that.
+timeoutProxy.check(checkPrivilege(RoleLevel.ALPHA_MOD));
+timeoutProxy.execute(async interaction => {
+  const member = interaction.options.getMember("user") as GuildMember;
+  const reason = interaction.options.getString("reason");
+
+  const duration = interaction.options.getString("duration") ?? "1 min";
+  const durationSeconds = durationToSeconds(duration, "minute");
+  if (durationSeconds === null || durationSeconds <= 0) {
+    await interaction.reply({
+      content: `Invalid duration ${inlineCode(duration)}!`,
+      ephemeral: true,
+    });
+    return false;
+  }
+
+  await member.timeout(durationSeconds * 1000, reason ?? undefined);
+  log.info(
+    `${formatContext(interaction)}: timed out @${member.user.username} ` +
+    `for ${formatHoursMinsSeconds(durationSeconds)} ` +
+    `with reason: ${reason ?? "(none given)"}`,
+  );
+
+  await replyWithGenericACK(interaction, { ephemeral: true }); // Stealth :)
+  return true;
+});
+
+const timeoutProxySpec = timeoutProxy.toSpec();
+export default timeoutProxySpec;

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -1,8 +1,10 @@
 import {
+  ChatInputCommandInteraction,
   DMChannel,
   EmojiResolvable,
   Events,
   GuildMember,
+  InteractionReplyOptions,
   Message,
   MessageCreateOptions,
   MessageFlags,
@@ -69,4 +71,15 @@ export const echoContent: ListenerExecuteFunction<Events.MessageCreate>
  */
 export async function getDMChannel(member: GuildMember): Promise<DMChannel> {
   return member.dmChannel ?? await member.createDM();
+}
+
+export async function replyWithGenericACK(
+  interaction: ChatInputCommandInteraction,
+  options?: Omit<InteractionReplyOptions, "content">,
+): Promise<void> {
+  await interaction.reply({
+    content: "👍",
+    ephemeral: true, // Default to ephemeral (possibly overridden thru options).
+    ...(options ?? {}),
+  });
 }

--- a/tests/controllers/moderation/timeout/timeout-proxy.command.test.ts
+++ b/tests/controllers/moderation/timeout/timeout-proxy.command.test.ts
@@ -1,0 +1,66 @@
+import { GuildMember } from "discord.js";
+
+import { ALPHA_MOD_RID, BABY_MOD_RID } from "../../../../src/config";
+import timeoutProxySpec from "../../../../src/controllers/moderation/timeout/timeout-proxy.command";
+import { RoleLevel } from "../../../../src/middleware/privilege.middleware";
+import { MockInteraction } from "../../../test-utils";
+
+let mock: MockInteraction;
+beforeEach(() => {
+  mock = new MockInteraction(timeoutProxySpec)
+    .mockCaller({ roleIds: [ALPHA_MOD_RID] })
+    .mockOption("User", "user", mockTarget);
+});
+
+const mockTarget = {
+  timeout: jest.fn(),
+  user: {
+    username: "dummyuser",
+  },
+} as unknown as GuildMember;
+
+it("should require privilege level >= ALPHA_MOD", async () => {
+  const unprivilegedMock = new MockInteraction(timeoutProxySpec)
+    .mockCaller({ roleIds: [BABY_MOD_RID] })
+    .mockOption("User", "user", mockTarget);
+
+  await unprivilegedMock.simulateCommand();
+
+  unprivilegedMock.expectMentionedMissingPrivilege(RoleLevel.ALPHA_MOD);
+});
+
+it("should time out the user for 1 minute by default", async () => {
+  await mock.simulateCommand();
+
+  expect(mockTarget.timeout).toHaveBeenCalledWith(60_000, undefined);
+  mock.expectRepliedGenericACK();
+});
+
+it("should time out the user for the time specified", async () => {
+  mock.mockOption("String", "duration", "16 min");
+
+  await mock.simulateCommand();
+
+  expect(mockTarget.timeout).toHaveBeenCalledWith(16 * 60_000, undefined);
+  mock.expectRepliedGenericACK();
+});
+
+it("should time out the user with the provided reason", async () => {
+  mock
+    .mockOption("String", "duration", "12 min")
+    .mockOption("String", "reason", "because i can");
+
+  await mock.simulateCommand();
+
+  expect(mockTarget.timeout).toHaveBeenCalledWith(12 * 60_000, "because i can");
+  mock.expectRepliedGenericACK();
+});
+
+it("should assume units of minutes if units are omitted", async () => {
+  mock.mockOption("String", "duration", "50");
+
+  await mock.simulateCommand();
+
+  expect(mockTarget.timeout).toHaveBeenCalledWith(50 * 60_000, undefined);
+  mock.expectRepliedGenericACK();
+});

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -170,6 +170,11 @@ export class MockInteraction {
     // null` is to pacify this TS error when switching param value from `any` to
     // `T`. Code still works as expected.
     options[`get${type}`].calledWith(name).mockReturnValue(value as null);
+    if (type === "User") {
+      // SlashCommandBuilder doesn't define an `addMemberOption`, but
+      // interaction.options has `getMember`...
+      options.getMember.calledWith(name).mockReturnValue(value as null);
+    }
     return this;
   }
 


### PR DESCRIPTION
A cheeky feature that allows members of sufficient privilege (`ALPHA_MOD`+ at the moment) to make the bot issue a timeout on their behalf. This is like a way to evade showing up as the timeout issuer in both the audit log and the existing timeout broadcast feature (#73).

A more practical use is that, because bots are granted more granular control over timeout durations, a moderator can use this command to time out for arbitrary durations instead of just the preset ones (60 seconds, 5 minutes, 10 minutes, 1 hour, 1 day, 1 week). **A catch is that, because of the fix implemented in #87 where the calculated _Duration_ field is rounded to the nearest minute, timing out with seconds level of precision means the duration that shows up on the broadcasted embeds may be slightly inaccurate.**