### PR TITLE
Reply "this is veri not funni" to "not funni"

### DIFF
--- a/src/controllers/users/ni/not-funni.listener.ts
+++ b/src/controllers/users/ni/not-funni.listener.ts
@@ -1,0 +1,29 @@
+import _ from "lodash";
+
+import env from "../../../config";
+import getLogger from "../../../logger";
+import {
+  channelPollutionAllowed,
+  contentMatching,
+} from "../../../middleware/filters.middleware";
+import { MessageListenerBuilder } from "../../../types/listener.types";
+import { replySilently } from "../../../utils/interaction.utils";
+import { formatContext } from "../../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+const notFunni = new MessageListenerBuilder().setId("not-funni");
+
+notFunni.filter(channelPollutionAllowed);
+notFunni.filter(contentMatching(/not funni/i));
+notFunni.execute(async message => {
+  const randNum = _.random(1, 5);
+  const veri = "veri".repeat(randNum);
+  const response = `this is ${veri} not funni`;
+  await replySilently(message, response);
+  log.info(`${formatContext(message)}: replied with '${response}'.`);
+});
+notFunni.cooldown({ type: "global", seconds: 60, bypassers: [env.NI_UID] });
+
+const notFunniSpec = notFunni.toSpec();
+export default notFunniSpec;

--- a/src/utils/math.utils.ts
+++ b/src/utils/math.utils.ts
@@ -1,5 +1,7 @@
 /**
  * Return a random integer in the inclusive range [`lower`, `upper`].
+ *
+ * @deprecated Use `_.random()` from lodash instead.
  */
 export function randRange(lower: number, upper: number): number {
   if (!Number.isInteger(lower)) {

--- a/tests/controllers/users/ni/not-funni.listener.test.ts
+++ b/tests/controllers/users/ni/not-funni.listener.test.ts
@@ -1,0 +1,33 @@
+import _ from "lodash";
+
+import notFunniSpec from "../../../../src/controllers/users/ni/not-funni.listener";
+import { MockMessage } from "../../../test-utils";
+
+let mock: MockMessage;
+beforeEach(() => { mock = new MockMessage(notFunniSpec); });
+
+it("should reply saying this is veri not funni", async () => {
+  mock.mockContent("this is veri not funni");
+  jest.spyOn(_, "random").mockReturnValueOnce(1);
+
+  await mock.simulateEvent();
+
+  mock.expectRepliedSilentlyWith("this is veri not funni");
+});
+
+it("should respond with a random number of veri", async () => {
+  mock.mockContent("this is veri not funni");
+  jest.spyOn(_, "random").mockReturnValueOnce(3);
+
+  await mock.simulateEvent();
+
+  mock.expectRepliedSilentlyWith("this is veriveriveri not funni");
+});
+
+it("should not respond if it's not not very funni", async () => {
+  mock.mockContent("hello there");
+
+  await mock.simulateEvent();
+
+  mock.expectNotResponded();
+});


### PR DESCRIPTION
This is veri not funni.

## Context

This simple feature is yet another continuation to the "deez" series -- low effort echoing of simple triggers. Other existing examples include (most of which originating from TempBot's Python predecessor):

* deez
* dab
* popipo (#35)
* sniffs (enhanced with #34, #48)
* uff
* uwu
* uwu cxtie (#71)

In the case of deez, dab, and uwu, they have their own threads spawned off of `#general` dedicated to just ~~brainrot~~ saying those words over and over again. "this is veri not funni" is the newest addition to this thread "trend".
