### PR TITLE
Handle "Reaction was blocked" (90001)

### DIFF
--- a/src/bot/listener.runner.ts
+++ b/src/bot/listener.runner.ts
@@ -1,6 +1,7 @@
 import { ClientEvents } from "discord.js";
 
 import getLogger from "../logger";
+import { isReactionBlocked } from "../types/errors.types";
 import { ListenerSpec } from "../types/listener.types";
 
 const log = getLogger(__filename);
@@ -108,6 +109,16 @@ export class ListenerRunner<Type extends keyof ClientEvents> {
   }
 
   protected handleListenerError(error: Error): void {
-    console.error(error);
+    if (isReactionBlocked(error)) {
+      // TODO: Maybe define a helper function that all controllers can use to
+      // react to a message such that errors can still be handled in one place
+      // but can have access to the message's context.
+      log.warning("reaction blocked.");
+    }
+    // Extend the if-else ladder for other error types to specially handle.
+    else {
+      console.error(error);
+    }
+
   }
 }

--- a/src/controllers/users/wys/yes-wys.listener.ts
+++ b/src/controllers/users/wys/yes-wys.listener.ts
@@ -1,12 +1,17 @@
 import env from "../../../config";
-import { messageFrom, randomly } from "../../../middleware/filters.middleware";
+import {
+  channelPollutionAllowed,
+  messageFrom,
+  randomly,
+} from "../../../middleware/filters.middleware";
 import { MessageListenerBuilder } from "../../../types/listener.types";
 import { replySilentlyWith } from "../../../utils/interaction.utils";
 
 const yesWys = new MessageListenerBuilder().setId("yes-wys");
 
+yesWys.filter(channelPollutionAllowed);
 yesWys.filter(messageFrom(env.WYS_UID));
-yesWys.filter(randomly(0.05));
+yesWys.filter(randomly(0.02));
 yesWys.execute(replySilentlyWith("yes wys"));
 
 const yesWysSpec = yesWys.toSpec();

--- a/src/types/errors.types.ts
+++ b/src/types/errors.types.ts
@@ -18,3 +18,8 @@ export function isMissingPermissions(error: unknown):
   error is DiscordAPIErrorWithCode<50013> {
   return error instanceof DiscordAPIError && error.code === 50013;
 }
+
+export function isReactionBlocked(error: unknown):
+  error is DiscordAPIErrorWithCode<90001> {
+  return error instanceof DiscordAPIError && error.code === 90001;
+}


### PR DESCRIPTION
See full list of Discord opcodes [here](https://discord.com/developers/docs/topics/opcodes-and-status-codes).

Also tacked on a change to the `yes-wys` listener (#75) to make it slightly less annoying:

* Decreased random react chance: 0.05 -> 0.02.
* Added `channelPollutionAllowed` filter such that it will no longer trigger in channels such as `#general`.