### PR TITLE
Add --disable-listeners (disable custom listeners)

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ should be environment variables.
 | `npm run clean`    | Clear JavaScript build files.                                                                |
 | `npm run build`    | Compile TypeScript source to JavaScript.                                                     |
 | `npm start`        | Start the bot runtime. This invokes Node.js on the compiled JavaScript ready for production. |
+| `npm run silent`   | Same as `npm run dev` but disable custom listeners.                                          |
 | `npm run now`      | Run existing JavaScript build files right away.                                              |
 | `npm test`         | Run tests.                                                                                   |
 | `npm run lint`     | Run the linter to report errors/warnings.                                                    |

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "start": "npm run build && node .",
     "now": "LOGGER_LEVEL=debug node .",
+    "silent": "LOGGER_LEVEL=debug ts-node src/index.ts --disable-listeners",
     "test": "jest",
     "lint": "eslint --ext .ts .",
     "lint:fix": "npm run lint -- --fix"

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -34,9 +34,11 @@ export class BotClient extends ClientWithIntentsAndRunnersABC {
     SPECIAL_LISTENERS_DIR_PATH,
   );
 
-  public override async prepareRuntime(): Promise<boolean> {
+  public override async prepareRuntime(
+    disableListeners = false,
+  ): Promise<boolean> {
     await this.loadCommands();
-    await this.loadListeners();
+    await this.loadListeners(disableListeners);
 
     try {
       this.registerListeners();
@@ -92,8 +94,8 @@ export class BotClient extends ClientWithIntentsAndRunnersABC {
     }
   }
 
-  private async loadListeners(): Promise<void> {
-    const allListenerSpecs = await this.listenerLoader.load();
+  private async loadListeners(specialOnly?: boolean): Promise<void> {
+    const allListenerSpecs = await this.listenerLoader.load(specialOnly);
     for (const spec of allListenerSpecs) {
       const { id, type } = spec;
       this.listenerRunners.set(id, new ListenerRunner(spec));

--- a/src/bot/listener.loader.ts
+++ b/src/bot/listener.loader.ts
@@ -71,11 +71,14 @@ export class ListenerLoader {
     return null;
   }
 
-  public async load(): Promise<ListenerSpec<any>[]> {
+  public async load(specialOnly?: boolean): Promise<ListenerSpec<any>[]> {
     const specs: ListenerSpec<any>[] = [];
     const customListenerPaths = this.discoverListenerFiles();
     const specialListenerPaths = this.discoverSpecialListenerFiles();
-    const listenerPaths = [...specialListenerPaths, ...customListenerPaths];
+
+    const listenerPaths = specialOnly
+      ? specialListenerPaths
+      : [...specialListenerPaths, ...customListenerPaths];
 
     for (const fullPath of listenerPaths) {
       const module = await dynamicRequire(fullPath);

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,12 @@ async function main() {
     return;
   }
 
-  log.info("preparing bot runtime...");
-  const success = client.prepareRuntime();
+  const disableListeners = process.argv.includes("--disable-listeners");
+  log.info(
+    "preparing bot runtime..." +
+    (disableListeners ? " (listeners disabled)" : ""),
+  );
+  const success = client.prepareRuntime(disableListeners);
   if (!success) process.exit(1);
 
   log.info("starting bot runtime...");

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -93,7 +93,7 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
    * state to log in and start its main event loop. Return whether the operation
    * succeeded.
    */
-  public abstract prepareRuntime(): Promise<boolean>;
+  public abstract prepareRuntime(disableListeners?: boolean): Promise<boolean>;
   /**
    * Load command definitions and deploy them to Discord's backend. It is
    * expected that this method does NOT start the bot's main runtime.


### PR DESCRIPTION
This can be useful when I want to launch the bot without custom listener functionality, which usually involves replying to users. This is exposed to the CLI as a new `--disable-listeners` flag. The interface of the classes involved (`BotClient`, `ListenerLoader`, etc.) have been modified in a backwards-compatible fashion.