### PR TITLE
Display definitions of word upon Wordle winner 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,4 @@ MUDAE_UID=432610292342587392
 # 3rd party services.
 DB_CONN_STRING=
 DB_NAME=yungkaiworldbotdb
+WORDNIK_API_KEY=

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -14,6 +14,7 @@ jobs:
       APPLICATION_ID: ${{ secrets.PROD_APPLICATION_ID }}
       DB_CONN_STRING: ${{ secrets.PROD_DB_CONN_STRING }}
       DB_NAME: ${{ vars.PROD_DB_NAME }}
+      WORDNIK_API_KEY: ${{ secrets.WORDNIK_API_KEY }}
 
       LUKE_UID: ${{ vars.LUKE_UID }}
       KLEE_UID: ${{ vars.KLEE_UID }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@devraelfreeze/discordjs-pagination": "^2.7.6",
+        "axios": "^1.6.7",
         "discord.js": "^14.14.1",
         "dotenv": "^16.3.1",
         "lodash": "^4.17.21",
@@ -23,6 +24,7 @@
         "zod-validation-error": "^2.1.0"
       },
       "devDependencies": {
+        "@types/argparse": "^2.0.14",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^29.5.11",
         "@types/lodash": "^4.14.202",
@@ -31,6 +33,7 @@
         "@types/node": "^20.10.5",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
+        "argparse": "^2.0.1",
         "eslint": "^8.56.0",
         "eslint-plugin-import-newlines": "^1.3.4",
         "jest": "^29.7.0",
@@ -1509,6 +1512,12 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
+    "node_modules/@types/argparse": {
+      "version": "2.0.14",
+      "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.14.tgz",
+      "integrity": "sha512-jJ6NMs9rXQ0rsqNt3TL4Elcwhd6wygo3lJOVoiHzURD34vsCcAlw443uGu4PXTtEmMF7sYKoadTCLXNmuJuQGw==",
+      "dev": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2166,6 +2175,21 @@
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
       "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
+      "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
+      "dependencies": {
+        "follow-redirects": "^1.15.4",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/babel-jest": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
@@ -2523,6 +2547,17 @@
         "text-hex": "1.0.x"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2624,6 +2659,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/detect-newline": {
@@ -3167,6 +3210,38 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.5.tgz",
+      "integrity": "sha512-vSFWUON1B+yAw1VN4xMfxgn5fTUiaOzAJCKBwIIgT/+7CuGy9+r+5gITvP62j3RmaD5Ph65UaERdOSRGUzZtgw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -4527,6 +4602,25 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -5013,6 +5107,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "license": "MIT",
   "devDependencies": {
+    "@types/argparse": "^2.0.14",
     "@types/dotenv": "^8.2.0",
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.14.202",
@@ -29,6 +30,7 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
+    "argparse": "^2.0.1",
     "eslint": "^8.56.0",
     "eslint-plugin-import-newlines": "^1.3.4",
     "jest": "^29.7.0",
@@ -39,6 +41,7 @@
   },
   "dependencies": {
     "@devraelfreeze/discordjs-pagination": "^2.7.6",
+    "axios": "^1.6.7",
     "discord.js": "^14.14.1",
     "dotenv": "^16.3.1",
     "lodash": "^4.17.21",

--- a/scripts/wordnik.js
+++ b/scripts/wordnik.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const { ArgumentParser } = require("argparse");
+const axios = require("axios").default;
+const dotenv = require("dotenv");
+
+dotenv.config();
+
+const WORDNIK_API_KEY = process.env.WORDNIK_API_KEY;
+
+const BASE_URL = "https://api.wordnik.com/v4";
+
+const apiConfig = {
+  definitions: (wordToSearch) =>
+    `${BASE_URL}/word.json/${wordToSearch}/definitions`,
+};
+
+const parser = new ArgumentParser({
+  description:
+    "Simple script for retrieving definitions for a word via the Wordnik API",
+});
+
+parser.add_argument("word", {
+  metavar: "WORD",
+  help: "word to search for",
+});
+parser.add_argument("-n", "--limit", {
+  type: "int",
+  help: "max number of definitions to return",
+});
+parser.add_argument("-f", "--full", {
+  action: "store_true",
+  help: "show full JSON for each word instead of simple version",
+});
+parser.add_argument("-p", "--part-of-speech", {
+  dest: "partOfSpeech",
+  choices: [
+    "noun",
+    "adjective",
+    "verb",
+    "adverb",
+    "interjection",
+    "pronoun",
+    "preposition",
+    "abbreviation",
+    "article",
+    "conjunction",
+    // There are more: https://developer.wordnik.com/docs#!/word/getDefinitions.
+  ],
+  help: "show only definitions for this part of speech",
+});
+parser.add_argument("-j", "--json", {
+  dest: "outputAsJSON",
+  action: "store_true",
+  help: "output in JSON-serialized format",
+});
+
+function printDefinitions(
+  data,
+  showFullDefinitions,
+  thisPartOfSpeechOnly,
+  outputAsJSON,
+) {
+  if (showFullDefinitions) {
+    if (outputAsJSON) {
+      console.log(JSON.stringify(data, null, 2));
+    }
+    else {
+      console.log(data);
+    }
+    return;
+  }
+
+  let simplified = data.map(({ partOfSpeech, text }) => ({
+    partOfSpeech,
+    definition: text,
+  }));
+  if (thisPartOfSpeechOnly) {
+    simplified = simplified.filter(({ partOfSpeech }) =>
+      partOfSpeech === thisPartOfSpeechOnly,
+    );
+  }
+  if (outputAsJSON) {
+    console.log(JSON.stringify(simplified, null, 2));
+  }
+  else {
+    console.log(simplified);
+  }
+}
+
+async function main() {
+  const args = parser.parse_args();
+  const {
+    word,
+    limit = undefined,
+    full = false,
+    partOfSpeech = null,
+    outputAsJSON = false,
+  } = args;
+
+  let response;
+  try {
+    response = await axios.get(apiConfig.definitions(word), {
+      params: {
+        api_key: WORDNIK_API_KEY,
+        limit,
+      },
+    });
+  }
+  catch (error) {
+    console.error(error);
+    return 1;
+  }
+
+  printDefinitions(response.data, full, partOfSpeech, outputAsJSON);
+  return 0;
+}
+
+main().then(process.exit);

--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,11 @@ export const STINKYS_FRIENDS_CID = "1102022714769821836";
 export const MUSIC_CHAT_CID = "1102108372565753916";
 export const GAMING_CID = "1102087663688884314";
 export const COOKING_TIME_CID = "1161041458590134434";
+/**
+ * The channel set aside to test bot commands without disturbing the real bot
+ * spam channel.
+ */
+export const EXPERIMENTAL_BOT_SPAM_CID = "1204000920720117760";
 
 export const BOT_DEV_RID = "1186942954095525908";
 export const KAI_RID = "1101995406994444299";

--- a/src/services/wordnik.service.ts
+++ b/src/services/wordnik.service.ts
@@ -1,0 +1,179 @@
+import axios, { AxiosError } from "axios";
+import { Collection } from "discord.js";
+
+import env from "../config";
+import getLogger from "../logger";
+import { RequireKeys, ResultPair } from "../types/generic.types";
+
+const log = getLogger(__filename);
+
+/**
+ * See the dropdown menu for `partOfSpeech` at:
+ * https://developer.wordnik.com/docs#!/word/getDefinitions.
+ */
+export type PartOfSpeech =
+  | "noun"
+  | "adjective"
+  | "verb"
+  | "adverb"
+  | "interjection"
+  | "pronoun"
+  | "preposition"
+  | "abbreviation"
+  | "affix"
+  | "article"
+  | "auxiliary-verb"
+  | "conjunction"
+  | "definite-article"
+  | "family-name"
+  | "given-name"
+  | "idiom"
+  | "imperative"
+  | "noun-plural"
+  | "noun-posessive" // API has misspelling.
+  | "past-participle"
+  | "phrasal-prefix"
+  | "proper-noun"
+  | "proper-noun-plural"
+  | "proper-noun-posessive" // API has misspelling.
+  | "suffix"
+  | "verb-intransitive"
+  | "verb-transitive"
+  ;
+
+/**
+ * See the dropdown menu for `sourceDictionaries` at:
+ * https://developer.wordnik.com/docs#!/word/getDefinitions.
+ */
+type SourceDictionary =
+  | "ahd-5"
+  | "century"
+  | "wiktionary"
+  | "webster"
+  | "wordnet"
+  ;
+
+/**
+ * Schema for ONE definition object in the array of objects returned by the
+ * Wordnik's word definitions endpoint. That is, the type for the response JSON
+ * should be `WordnikDefinitionPayload[]`.
+ *
+ * See `Inline Model 1` at:
+ * https://developer.wordnik.com/docs#!/word/getDefinitions.
+ *
+ * Some type narrowing was inferred from playing around with the API using the
+ * codebase's Wordnik script.
+ */
+type WordnikDefinitionPayload<Word extends string = string> = {
+  attributionText?: string;
+  attributionUrl?: string;
+  citations: unknown[];
+  exampleUses: object[];
+  extendedText?: string;
+  labels: unknown[];
+  notes: unknown[];
+  partOfSpeech?: PartOfSpeech;
+  relatedWords: unknown[];
+  score?: number;
+  seqString?: string;
+  sequence?: `${number}`;
+  sourceDictionary?: SourceDictionary;
+  text?: string;
+  textProns: unknown[];
+  word: Word;
+};
+
+type SimplifiedDefinitionPayload = {
+  partOfSpeech: PartOfSpeech;
+  definition: string;
+};
+
+/**
+ * Wrapper of Axios methods for interacting with REST APIs.
+ *
+ * TODO: Move this to a shared helper module when a new service can use this
+ * too.
+ */
+class RESTService<B extends string> {
+  private instance = axios.create({ baseURL: this.baseUrl });
+
+  constructor(
+    /** Base URL of REST API to consume. */
+    public readonly baseUrl: B,
+  ) { }
+
+  public async get<R = unknown>(
+    endpoint: string,
+    params?: Record<string, any>,
+  ): ResultPair<R, AxiosError> {
+    try {
+      const response = await this.instance.get<R>(endpoint, { params });
+      return [response.data, null];
+    }
+    catch (error) {
+      return [null, error as AxiosError];
+    }
+  }
+
+  // ... other methods in the future ...
+}
+
+export class WordnikService {
+  private readonly apiConfig = {
+    definitions: <Word extends string>(wordToSearch: Word) =>
+      `/word.json/${wordToSearch}/definitions` as const,
+  };
+  private readonly rest = new RESTService("https://api.wordnik.com/v4");
+
+  /**
+   * Return a mapping from part of speech to definitions of that part of speech.
+   */
+  public async getDefinitions<Word extends string>(word: Word): Promise<
+    | Collection<PartOfSpeech, string[]>
+    | "Not Found"
+    | "Unknown Error"
+  > {
+    const [defs, error] = await this.rest.get<WordnikDefinitionPayload[]>(
+      this.apiConfig.definitions(word),
+      { api_key: env.WORDNIK_API_KEY },
+    );
+
+    if (error) {
+      // Wordnik returns 404 if the word doesn't exist.
+      if (error.response?.status === 404) {
+        return "Not Found";
+      }
+      log.error("unknown error in calling Wordnik API.");
+      console.error(error);
+      return "Unknown Error";
+    }
+
+    const simplifiedDefinitions = this.simplifyDefinitionObjects(defs);
+    const result = new Collection<PartOfSpeech, string[]>();
+    for (const { partOfSpeech, definition } of simplifiedDefinitions) {
+      let definitionTexts = result.get(partOfSpeech);
+      if (!definitionTexts) {
+        definitionTexts = [];
+        result.set(partOfSpeech, definitionTexts);
+      }
+      definitionTexts.push(definition);
+    }
+    return result;
+  }
+
+  private simplifyDefinitionObjects(
+    definitions: WordnikDefinitionPayload[],
+  ): SimplifiedDefinitionPayload[] {
+    // Not all entries have the partOfSpeech and text for some reason.
+    const filtered = definitions.filter(def => def.partOfSpeech && def.text) as
+      RequireKeys<WordnikDefinitionPayload, "partOfSpeech" | "text">[];
+
+    return filtered.map(def => ({
+      partOfSpeech: def.partOfSpeech,
+      // Also remove the weird XML (?) tags.
+      definition: def.text.replace(/<\/?.+?>/g, ""),
+    }));
+  }
+}
+
+export default new WordnikService();

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -71,6 +71,10 @@ declare global {
      * Name of MongoDB database to use.
      */
     DB_NAME: string;
+    /**
+     * API Key for the Wordnik API, an English dictionary service.
+     */
+    WORDNIK_API_KEY: string;
   };
 
   namespace NodeJS {

--- a/src/types/generic.types.ts
+++ b/src/types/generic.types.ts
@@ -1,0 +1,26 @@
+// Utilities for TypeScript generics.
+
+
+/**
+ * Return `T` with the keys included in `K` made required.
+ *
+ * Example:
+ *
+ *    ```
+ *    type VerifiedPerson = RequireKeys<Person, "name" | "color">;
+ *    ```
+ *
+ * Ref: https://stackoverflow.com/a/66680470/14226122
+ */
+export type RequireKeys<T extends object, K extends keyof T> =
+  (Required<Pick<T, K>> & Omit<T, K>) extends
+  infer O ? { [P in keyof O]: O[P] } : never;
+
+/**
+ * Discriminated union for a result-error pair returned by a typical service
+ * function.
+ */
+export type ResultPair<ResultType, ErrorType extends Error = Error> = Promise<
+  | [ResultType, null]
+  | [null, ErrorType]
+>;


### PR DESCRIPTION
Now that I have my API key from [Wordnik](https://www.wordnik.com/) (since a while ago, actually), I can implement the service that fetches definitions for a word and finally complete the Wordle port (#97).

## Main Changes

* New environment variable and repository secret: `WORDNIK_API_KEY`.
* Added a script with an [argparse-like](https://www.npmjs.com/package/argparse) CLI to play around with the Wordnik [definitions endpoint](https://developer.wordnik.com/docs#!/word/getDefinitions).
* Implemented the `WordnikService` to abstract interacting with the Wordnik API. This service itself delegates to a new `RESTService` class (via the *composition* design pattern), which was not really necessary, but I thought generalizing a wrapper for Axios requests would come in handy later down the line anyway.
* Updated the Wordle listener to now include the word's definitions when a winner is declared.

## Other Changes

* Added a new `types/` module for TypeScript-related utilities (notably generics).
* Added a new channel to the CID config: an "experimental bot spam" channel, which is private. This shall be used for testing bot features without disturbing the real `#bot-spam`.

## Todos/Warnings

* The Wordnik API seems to return *many* definitions for each word (some of which seem kind of redundant, but I wouldn't know how to filter that out) -- much more than PyDictionary. This means there could be the case where trying to display the definitions causes the winner's embed description to exceed the character limit and throw an error when trying to send it.
* I'm not sure if the aforementioned `RESTService` is necessary and/or well-architected. If it is, it should be moved into its own shared helper module when we add the next service that might want to use it.