### PR TITLE
Add /dictionary to look up definitions for word

### DIFF
--- a/src/controllers/convenience/dictionary.command.ts
+++ b/src/controllers/convenience/dictionary.command.ts
@@ -1,0 +1,67 @@
+import {
+  EmbedBuilder,
+  SlashCommandBuilder,
+  inlineCode,
+  roleMention,
+} from "discord.js";
+
+import { BOT_DEV_RID } from "../../config";
+import wordnikService from "../../services/wordnik.service";
+import { CommandBuilder } from "../../types/command.types";
+import { toBulletedList } from "../../utils/markdown.utils";
+import { addEphemeralOption } from "../../utils/options.utils";
+
+const dictionary = new CommandBuilder();
+
+const slashCommandDefinition = new SlashCommandBuilder()
+  .setName("dictionary")
+  .setDescription("Look up the definition(s) of a word")
+  .addStringOption(input => input
+    .setName("word")
+    .setDescription("The word to search for.")
+    .setRequired(true),
+  );
+addEphemeralOption(slashCommandDefinition);
+
+dictionary.define(slashCommandDefinition);
+// TODO: Commands should have a cooldown mechanism too. With external APIs like
+// Wordnik, we don't want users to cause a 429.
+dictionary.execute(async interaction => {
+  const word = interaction.options.getString("word", true);
+  const ephemeral = !!interaction.options.getBoolean("ephemeral");
+
+  const definitions = await wordnikService.getDefinitions(word);
+  if (definitions === "Not Found") {
+    await interaction.reply({
+      content: `I don't think ${inlineCode(word)} is a valid word!`,
+      ephemeral: true,
+    });
+    return false;
+  }
+  if (definitions === "Unknown Error") {
+    await interaction.reply({
+      content:
+        "Oops! My dictionary service is experiencing unexpected difficulties " +
+        `right now. Try again later or let a ${roleMention(BOT_DEV_RID)} know!`,
+      ephemeral: true,
+    });
+    return false;
+  }
+
+  const embed = new EmbedBuilder().setTitle(word);
+  for (const [partOfSpeech, definitionEntries] of definitions) {
+    embed.addFields({
+      name: partOfSpeech,
+      value: toBulletedList(definitionEntries),
+    });
+  }
+
+  await interaction.reply({
+    embeds: [embed],
+    ephemeral,
+  });
+  return true;
+});
+
+const dictionarySpec = dictionary.toSpec();
+export default dictionarySpec;

--- a/tests/controllers/convenience/dictionary.command.test.ts
+++ b/tests/controllers/convenience/dictionary.command.test.ts
@@ -1,0 +1,77 @@
+jest.mock("../../../src/services/wordnik.service");
+
+import {
+  APIEmbed,
+  Collection,
+  EmbedBuilder,
+  inlineCode,
+  roleMention,
+} from "discord.js";
+import { Matcher } from "jest-mock-extended";
+import _ from "lodash";
+
+import { BOT_DEV_RID } from "../../../src/config";
+import dictionarySpec from "../../../src/controllers/convenience/dictionary.command";
+import wordnikService, {
+  PartOfSpeech,
+} from "../../../src/services/wordnik.service";
+import { MockInteraction } from "../../test-utils";
+
+let mock: MockInteraction;
+beforeEach(() => { mock = new MockInteraction(dictionarySpec); });
+
+it("should look up the definition of a word", async () => {
+  mock.mockOption("String", "word", "board");
+  const dummyDefinitions = new Collection<PartOfSpeech, string[]>([
+    ["noun", ["noun definition 1", "noun definition 2"]],
+    ["verb", ["verb definition 1", "verb definition 2"]],
+    ["adjective", ["adjective definition 1", "adjective definition 2"]],
+  ]);
+  jest.mocked(wordnikService.getDefinitions)
+    .mockResolvedValueOnce(dummyDefinitions);
+
+  await mock.simulateCommand();
+
+  const embedMatcher = new Matcher<EmbedBuilder>(embed => {
+    const correctTitle = embed.data.title === "board";
+    const correctFieldTitles = _.isEqual(
+      embed.data.fields?.map(field => field.name),
+      ["noun", "verb", "adjective"],
+    );
+    return correctTitle && correctFieldTitles;
+  }, "embed matcher");
+  mock.expectRepliedWith({
+    embeds: [embedMatcher as unknown as APIEmbed],
+  });
+});
+
+describe("error handling", () => {
+  it("should gracefully handle unknown words", async () => {
+    const dummyWord = "fdahskulghalkgha";
+    mock.mockOption("String", "word", dummyWord);
+    jest.mocked(wordnikService.getDefinitions)
+      .mockResolvedValueOnce("Not Found");
+
+    await mock.simulateCommand();
+
+    mock.expectRepliedWith({
+      content: `I don't think ${inlineCode(dummyWord)} is a valid word!`,
+      ephemeral: true,
+    });
+  });
+
+  it("should gracefully handle unknown service errors", async () => {
+    mock.mockOption("String", "word", "board");
+    jest.mocked(wordnikService.getDefinitions)
+      .mockResolvedValueOnce("Unknown Error");
+
+    await mock.simulateCommand();
+
+    mock.expectRepliedWith({
+      content:
+        "Oops! My dictionary service is experiencing unexpected difficulties " +
+        `right now. Try again later or let a ${roleMention(BOT_DEV_RID)} know!`,
+      ephemeral: true,
+    });
+  });
+});


### PR DESCRIPTION
Added a new `/dictionary [word]` command that uses the Wordnik API introduced in #105.

Same cautionary note as in #105:

> * The Wordnik API seems to return *many* definitions for each word (some of which seem kind of redundant, but I wouldn't know how to filter that out) -- much more than PyDictionary. This means there could be the case where trying to display the definitions causes the [...] embed description to exceed the character limit and throw an error when trying to send it.