### PR TITLE
Fix iterateEnum

### DIFF
--- a/src/controllers/dev/presence.command.ts
+++ b/src/controllers/dev/presence.command.ts
@@ -25,10 +25,7 @@ export type PresenceUpdateStatusName
   = Exclude<keyof typeof PresenceUpdateStatus, "Offline">;
 
 const activityTypeNames: ActivityTypeName[]
-  = iterateEnum(ActivityType)
-    .map(([name]) => name)
-    // TODO: enum values (numbers) being included through iterateEnum somehow.
-    .filter(name => isNaN(Number(name)));
+  = iterateEnum(ActivityType).map(([name]) => name);
 const activityChoices: Choice<ActivityTypeName>[]
   = activityTypeNames.map(name => ({ name, value: name }));
 

--- a/src/middleware/privilege.middleware.ts
+++ b/src/middleware/privilege.middleware.ts
@@ -3,7 +3,6 @@ import { CommandInteraction, GuildMember, roleMention } from "discord.js";
 import { ALPHA_MOD_RID, BABY_MOD_RID, BOT_DEV_RID, KAI_RID } from "../config";
 import getLogger from "../logger";
 import { CommandCheck } from "../types/command.types";
-import { iterateEnum } from "../utils/iteration.utils";
 import { formatContext } from "../utils/logging.utils";
 
 const log = getLogger(__filename);
@@ -54,10 +53,12 @@ export function checkPrivilege(
   memberToCheck?: GuildMember,
 ): boolean | CommandCheck {
   function isAuthorized(member: GuildMember): boolean {
-    for (const [level, roleId] of iterateEnum(LEVEL_TO_RID)) {
+    for (const level of Object.keys(LEVEL_TO_RID)) {
+      const levelValue = Number(level) as Exclude<RoleLevel, RoleLevel.NONE>;
+      const roleId = LEVEL_TO_RID[levelValue];
       // As long as the level required by the command is less than any of the
       // levels for which the caller has a role, then they pass.
-      if (commandLevel <= level && member.roles.cache.has(roleId)) {
+      if (commandLevel <= levelValue && member.roles.cache.has(roleId)) {
         return true;
       }
     }

--- a/tests/utils/iteration.utils.test.ts
+++ b/tests/utils/iteration.utils.test.ts
@@ -1,4 +1,5 @@
 import { Collection, Role } from "discord.js";
+
 import {
   getAllMembers,
   getAllPermute2,
@@ -6,12 +7,11 @@ import {
   unorderedEquals,
 } from "../../src/utils/iteration.utils";
 
-describe.skip("iterating over an enum", () => {
+describe("iterating over an enum", () => {
   enum DummyEnum { A = 0, B, C }
 
   it("should yield name-value pairs", () => {
     const result = iterateEnum(DummyEnum);
-    // TODO: the order within each 2-tuple seems to be flipped as well!
     expect(result).toEqual([
       ["A", 0],
       ["B", 1],


### PR DESCRIPTION
Closes #2.

* `iterateEnum` now works as expected when called with TypeScript `enum`s. Removing the explicit filter in the presence command controller reveals that the fix works.
* This fix actually broke the privilege middleware, which was passing in a normal JavaScript object (`Record`) instead of a TypeScript `enum`. The reason it was working while the presence module wasn't was because `iterateEnum` itself was incorrectly implementing iteration for `Record`s instead of `enum`s like intended. The privilege middleware's code has been refactored to just use `Object.keys()` and type assertions.
* Finally un-skipped the test for `iterateEnum` in `iteration.utils.test.ts`. There are now no longer any skipped tests.