### PR TITLE
Rework "stealth mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ should be environment variables.
 | `npm run clean`    | Clear JavaScript build files.                                                                |
 | `npm run build`    | Compile TypeScript source to JavaScript.                                                     |
 | `npm start`        | Start the bot runtime. This invokes Node.js on the compiled JavaScript ready for production. |
-| `npm run silent`   | Same as `npm run dev` but disable custom listeners.                                          |
+| `npm run stealth`  | Same as `npm run dev` but run in "stealth mode".                                             |
 | `npm run now`      | Run existing JavaScript build files right away.                                              |
 | `npm test`         | Run tests.                                                                                   |
 | `npm run lint`     | Run the linter to report errors/warnings.                                                    |

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "npm run clean && tsc --project tsconfig.build.json",
     "start": "npm run build && node .",
     "now": "LOGGER_LEVEL=debug node .",
-    "silent": "LOGGER_LEVEL=debug ts-node src/index.ts --disable-listeners",
+    "stealth": "LOGGER_LEVEL=debug ts-node src/index.ts --stealth",
     "test": "jest",
     "lint": "eslint --ext .ts .",
     "lint:fix": "npm run lint -- --fix"

--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -34,11 +34,9 @@ export class BotClient extends ClientWithIntentsAndRunnersABC {
     SPECIAL_LISTENERS_DIR_PATH,
   );
 
-  public override async prepareRuntime(
-    disableListeners = false,
-  ): Promise<boolean> {
+  public override async prepareRuntime(): Promise<boolean> {
     await this.loadCommands();
-    await this.loadListeners(disableListeners);
+    await this.loadListeners();
 
     try {
       this.registerListeners();
@@ -105,8 +103,8 @@ export class BotClient extends ClientWithIntentsAndRunnersABC {
     }
   }
 
-  private async loadListeners(specialOnly?: boolean): Promise<void> {
-    const allListenerSpecs = await this.listenerLoader.load(specialOnly);
+  private async loadListeners(): Promise<void> {
+    const allListenerSpecs = await this.listenerLoader.load(this.stealth);
     for (const spec of allListenerSpecs) {
       const { id, type } = spec;
       this.listenerRunners.set(id, new ListenerRunner(spec));
@@ -139,9 +137,3 @@ export class BotClient extends ClientWithIntentsAndRunnersABC {
     log.warning(`removed ${numListeners} listeners from client mapping.`);
   }
 }
-
-/**
- * Singleton bot to use when starting the bot runtime normally or deploying
- * slash commands.
- */
-export default new BotClient();

--- a/src/bot/listeners/ready.listener.ts
+++ b/src/bot/listeners/ready.listener.ts
@@ -8,17 +8,24 @@ import { ListenerBuilder, ListenerSpec } from "../../types/listener.types";
 const log = getLogger(__filename);
 
 async function handleReady(client: Client): Promise<void> {
+  const botClient = client as ClientWithIntentsAndRunnersABC;
+
   const now = new Date();
-  (client as ClientWithIntentsAndRunnersABC).readySince = now;
-  log.info(`bot ready! Logged in as ${client.user!.tag}.`);
+  botClient.readySince = now;
+  log.info(`bot ready! Logged in as ${botClient.user!.tag}.`);
 
   const presence = await settingsService.getPresence();
   if (!presence) return;
-  await client.user!.setActivity({
+  await botClient.user!.setActivity({
     name: presence.activity_name,
     type: ActivityType[presence.activity_type],
   });
   log.info(`set startup activity to: ${JSON.stringify(presence)}.`);
+
+  if (botClient.stealth) {
+    await botClient.user!.setStatus("invisible");
+    log.info("client is in stealth mode, set status to invisible.");
+  }
 }
 
 const onReady: ListenerSpec<Events.ClientReady>

--- a/src/controllers/dev/ping.command.ts
+++ b/src/controllers/dev/ping.command.ts
@@ -2,6 +2,7 @@ import {
   ChatInputCommandInteraction,
   SlashCommandBuilder,
   TimestampStyles,
+  bold,
   time,
 } from "discord.js";
 
@@ -36,7 +37,9 @@ async function respondWithDevDetails(
     }
   }
 
-  const { branchName, readySince } = client;
+  const { branchName, readySince, stealth } = client;
+
+  text += `\n* Mode: ${bold(stealth ? "Stealth" : "Normal")}`;
 
   if (branchName) {
     text += `\n* Branch: \`${branchName}\``;

--- a/src/controllers/dev/reload.command.ts
+++ b/src/controllers/dev/reload.command.ts
@@ -1,6 +1,8 @@
 import {
   ChatInputCommandInteraction,
+  Client,
   EmbedBuilder,
+  Events,
   SlashCommandBuilder,
 } from "discord.js";
 
@@ -47,12 +49,14 @@ class ClientReloadPipeline {
       success
         = await this.clearDefinitions()
         && await this.deploySlashCommands()
-        && await this.prepareRuntime();
+        && await this.prepareRuntime()
+        && await this.reemitReadyEvent();
     }
     else {
       success
         = await this.clearDefinitions()
-        && await this.prepareRuntime();
+        && await this.prepareRuntime()
+        && await this.reemitReadyEvent();
     }
     if (!success) return;
 
@@ -115,6 +119,18 @@ class ClientReloadPipeline {
     );
     await this.logAndReplyWithError(customError);
     return false;
+  }
+
+  private async reemitReadyEvent(): Promise<boolean> {
+    try {
+      this.client.emit(Events.ClientReady, this.client as Client<true>);
+      return true;
+    }
+    catch (error) {
+      log.crit(`${this.context}: error in re-emitting client ready event.`);
+      await this.logAndReplyWithError(error as Error);
+      return false;
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,27 +1,25 @@
 // Program entry point.
 
-import client from "./bot/client";
+import { BotClient } from "./bot/client";
 import env from "./config";
 import getLogger from "./logger";
 
 const log = getLogger(__filename);
 
 async function main() {
+  const stealth = process.argv.includes("--stealth");
+  const client = new BotClient(stealth);
+
   if (process.argv.includes("--sync")) {
     log.warning("deploying slash commands only...");
     await client.deploySlashCommands();
     return;
   }
 
-  const disableListeners = process.argv.includes("--disable-listeners");
-  log.info(
-    "preparing bot runtime..." +
-    (disableListeners ? " (listeners disabled)" : ""),
-  );
-  const success = client.prepareRuntime(disableListeners);
+  const success = client.prepareRuntime();
   if (!success) process.exit(1);
 
-  log.info("starting bot runtime...");
+  log.info(`starting bot runtime... (stealth=${stealth})`);
   await client.login(env.BOT_TOKEN);
 }
 

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -32,7 +32,7 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
    */
   public branchName = getCurrentBranchName();
 
-  constructor() {
+  constructor(public stealth: boolean) {
     super({
       intents: [
         GatewayIntentBits.Guilds,
@@ -93,7 +93,7 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
    * state to log in and start its main event loop. Return whether the operation
    * succeeded.
    */
-  public abstract prepareRuntime(disableListeners?: boolean): Promise<boolean>;
+  public abstract prepareRuntime(): Promise<boolean>;
   /**
    * Load command definitions and deploy them to Discord's backend. It is
    * expected that this method does NOT start the bot's main runtime.

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -1,4 +1,4 @@
-import { TimestampStyles, time } from "discord.js";
+import { TimestampStyles, bold, time } from "discord.js";
 
 import pingSpec from "../../../src/controllers/dev/ping.command";
 import { MockInteraction, TestClient, addMockGetter } from "../../test-utils";
@@ -16,6 +16,7 @@ describe("/ping command", () => {
 
     const mockClient = new TestClient();
     mockClient.readySince = dummyReadySince;
+    mockClient.stealth = true;
     addMockGetter(mockClient, "branchName", dummyBranchName);
     addMockGetter(mockClient.ws, "ping", dummyPing);
     mock.mockClient(mockClient);
@@ -26,6 +27,7 @@ describe("/ping command", () => {
     const relativeTime = time(dummyReadySince, TimestampStyles.RelativeTime);
     const expectedParts = [
       `Latency: **${dummyPing}**`,
+      `Mode: ${bold("Stealth")}`,
       `Branch: \`${dummyBranchName}\``,
       `Ready: ${timestamp} (${relativeTime})`,
     ];

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -71,6 +71,38 @@ it("should update the client's branch name", async () => {
   expect(mock.client.branchName).toEqual("DUMMY-BRANCH-NAME");
 });
 
+describe("stealth mode setting", () => {
+  beforeEach(() => {
+    mock.mockCaller({ roleIds: [BOT_DEV_RID] });
+  });
+
+  it("should reload with stealth mode enabled", async () => {
+    mock.mockOption("Boolean", "stealth_mode", true);
+    mock.client.stealth = false;
+
+    await mock.simulateCommand();
+
+    expect(mock.client.stealth).toEqual(true);
+  });
+
+  it("should reload with stealth mode disabled", async () => {
+    mock.mockOption("Boolean", "stealth_mode", false);
+    mock.client.stealth = true;
+
+    await mock.simulateCommand();
+
+    expect(mock.client.stealth).toEqual(false);
+  });
+
+  it("should preserve the stealth mode setting if omitted", async () => {
+    mock.client.stealth = true;
+
+    await mock.simulateCommand();
+
+    expect(mock.client.stealth).toEqual(true);
+  });
+});
+
 describe("error handling", () => {
   beforeEach(() => {
     mock

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -28,6 +28,7 @@ it("should require privilege level >= DEV", async () => {
   expect(mock.client.clearDefinitions).not.toHaveBeenCalled();
   expect(mock.client.deploySlashCommands).not.toHaveBeenCalled();
   expect(mock.client.prepareRuntime).not.toHaveBeenCalled();
+  expect(mock.client.emit).not.toHaveBeenCalled();
   mock.expectRepliedWith({
     // Any mention of the DEV level.
     content: expect.stringMatching(/\bDEV\b/i),
@@ -45,6 +46,7 @@ it("should clear defs, deploy commands, and reload defs", async () => {
   expect(mock.client.clearDefinitions).toHaveBeenCalled();
   expect(mock.client.deploySlashCommands).toHaveBeenCalled();
   expect(mock.client.prepareRuntime).toHaveBeenCalled();
+  expect(mock.client.emit).toHaveBeenCalled();
   mock.expectRepliedWith({ ephemeral: true });
 });
 
@@ -56,6 +58,7 @@ it("shouldn't deploy commands if option not explicitly set", async () => {
   expect(mock.client.clearDefinitions).toHaveBeenCalled();
   expect(mock.client.deploySlashCommands).not.toHaveBeenCalled();
   expect(mock.client.prepareRuntime).toHaveBeenCalled();
+  expect(mock.client.emit).toHaveBeenCalled();
   mock.expectRepliedWith({ ephemeral: true });
 });
 
@@ -117,7 +120,7 @@ describe("error handling", () => {
     });
   }
 
-  it("should false from prepareRuntime as a failure", async () => {
+  it("should treat false from prepareRuntime as a failure", async () => {
     mock.client.prepareRuntime.mockResolvedValueOnce(false);
 
     await mock.simulateCommand();

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -21,7 +21,7 @@ beforeEach(() => {
 });
 
 it("should require privilege level >= DEV", async () => {
-  mock.mockCallerRoles(KAI_RID);
+  mock.mockCaller({ roleIds: [KAI_RID] });
 
   await mock.simulateCommand();
 
@@ -38,7 +38,7 @@ it("should require privilege level >= DEV", async () => {
 
 it("should clear defs, deploy commands, and reload defs", async () => {
   mock
-    .mockCallerRoles(BOT_DEV_RID)
+    .mockCaller({ roleIds: [BOT_DEV_RID] })
     .mockOption("Boolean", "redeploy_slash_commands", true);
 
   await mock.simulateCommand();
@@ -51,7 +51,7 @@ it("should clear defs, deploy commands, and reload defs", async () => {
 });
 
 it("shouldn't deploy commands if option not explicitly set", async () => {
-  mock.mockCallerRoles(BOT_DEV_RID);
+  mock.mockCaller({ roleIds: [BOT_DEV_RID] });
 
   await mock.simulateCommand();
 
@@ -63,7 +63,7 @@ it("shouldn't deploy commands if option not explicitly set", async () => {
 });
 
 it("should update the client's branch name", async () => {
-  mock.mockCallerRoles(BOT_DEV_RID);
+  mock.mockCaller({ roleIds: [BOT_DEV_RID] });
   mockedGetCurrentBranchName.mockReturnValueOnce("DUMMY-BRANCH-NAME");
 
   await mock.simulateCommand();
@@ -74,7 +74,7 @@ it("should update the client's branch name", async () => {
 describe("error handling", () => {
   beforeEach(() => {
     mock
-      .mockCallerRoles(BOT_DEV_RID)
+      .mockCaller({ roleIds: [BOT_DEV_RID] })
       .mockOption("Boolean", "redeploy_slash_commands", true);
 
     // Also suppress console.error output.

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -289,6 +289,8 @@ export function addMockGetter<ObjectType extends object, ValueType>(
  * mocks.
  */
 export class TestClient extends ClientWithIntentsAndRunnersABC {
+  constructor() { super(false); }
+
   public override deploySlashCommands = jest.fn();
   public override prepareRuntime = jest.fn();
   public override clearDefinitions = jest.fn();


### PR DESCRIPTION
## Overview

Reworked the "disabled listeners mode" (#103) into a general "stealth mode". In stealth mode, the bot:

* Does not load any custom listeners (special listeners such as `READY` and `COMMAND-DISPATCH` are still loaded, as they are critical to the bot itself).
* Sets its presence status to **invisible**. Bringing the bot _out_ of stealth mode should set its status to **online**.

The motivation for such a mode is to be able to fiddle around with certain features of the bot on the server without having to worry about users believing the bot is online and available to offer any of its services.

## Changes

The bot ABC now exposes `stealth` property, and this is set at construction. This also means that `bot/client.ts` no longer exports a singleton but rather just the `BotClient` class, giving the entry point `index.ts` the freedom of passing in the initial value for `stealth` as determined by command line arguments. This PR also modifies the existing `/reload` (#63) and `/ping` commands:

* `/reload` now supports an optional Boolean `stealth_mode` option. When provided, its value is used to set the bot's stealth mode upon reloading. This makes it so that a bot can switch in and out of stealth mode at runtime instead of having to rerun the process with a different command line flag. This also added an extra step to the `ClientReloadPipeline` Namely, the pipeline now ends with making the client re-emit the `ClientReady` event. This is to re-run any setup code defined in the client's special `READY` listener upon reload. 
* The response to `/ping` now indicates if the bot is currently in stealth mode. It does so with a new "Mode:" entry, which is intentionally general to suggest support for future modes.

## Other Changes

* Changed the npm script from `npm run silent` to `npm run stealth`.
* Changed the command line flag from `--disable-listeners` to `--stealth`.
* Reworked the interface of `BotClient` a bit, making "stealth" a property to be set on initialization instead of something to pass into `prepareRuntime`.
* Removed calls to the deprecated `MockInteraction#mockCallerRoles` in `/reload`'s test module.