### PR TITLE
Destroy the client on SIGINT

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,12 @@ async function main() {
   const success = client.prepareRuntime();
   if (!success) process.exit(1);
 
+  process.on("SIGINT", async () => {
+    await client.destroy();
+    log.warning("program terminating by SIGINT, client destroyed.");
+    process.exit(130);
+  });
+
   log.info(`starting bot runtime... (stealth=${stealth})`);
   await client.login(env.BOT_TOKEN);
 }


### PR DESCRIPTION
The vast majority of bot terminations seem to be through using <kbd>Ctrl</kbd>+<kbd>C</kbd> (the other options being an unexpected uncaught error or the `/shutdown` command). However, this does not cleanly close the connection to Discord. This can be observed from how the bot appears online for some time even after terminating the program. To solve this, the program entry point `index.ts` now explicitly calls the `Client#destroy` method when the `SIGINT` signal is detected.