### PR TITLE
Use argparse for parsing CLI options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@devraelfreeze/discordjs-pagination": "^2.7.6",
+        "@types/argparse": "^2.0.14",
+        "argparse": "^2.0.1",
         "axios": "^1.6.7",
         "discord.js": "^14.14.1",
         "dotenv": "^16.3.1",
@@ -24,7 +26,6 @@
         "zod-validation-error": "^2.1.0"
       },
       "devDependencies": {
-        "@types/argparse": "^2.0.14",
         "@types/dotenv": "^8.2.0",
         "@types/jest": "^29.5.11",
         "@types/lodash": "^4.14.202",
@@ -33,7 +34,6 @@
         "@types/node": "^20.10.5",
         "@typescript-eslint/eslint-plugin": "^6.18.1",
         "@typescript-eslint/parser": "^6.18.1",
-        "argparse": "^2.0.1",
         "eslint": "^8.56.0",
         "eslint-plugin-import-newlines": "^1.3.4",
         "jest": "^29.7.0",
@@ -1515,8 +1515,7 @@
     "node_modules/@types/argparse": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-2.0.14.tgz",
-      "integrity": "sha512-jJ6NMs9rXQ0rsqNt3TL4Elcwhd6wygo3lJOVoiHzURD34vsCcAlw443uGu4PXTtEmMF7sYKoadTCLXNmuJuQGw==",
-      "dev": true
+      "integrity": "sha512-jJ6NMs9rXQ0rsqNt3TL4Elcwhd6wygo3lJOVoiHzURD34vsCcAlw443uGu4PXTtEmMF7sYKoadTCLXNmuJuQGw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2158,8 +2157,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-union": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "license": "MIT",
   "devDependencies": {
-    "@types/argparse": "^2.0.14",
     "@types/dotenv": "^8.2.0",
     "@types/jest": "^29.5.11",
     "@types/lodash": "^4.14.202",
@@ -30,7 +29,6 @@
     "@types/node": "^20.10.5",
     "@typescript-eslint/eslint-plugin": "^6.18.1",
     "@typescript-eslint/parser": "^6.18.1",
-    "argparse": "^2.0.1",
     "eslint": "^8.56.0",
     "eslint-plugin-import-newlines": "^1.3.4",
     "jest": "^29.7.0",
@@ -41,6 +39,8 @@
   },
   "dependencies": {
     "@devraelfreeze/discordjs-pagination": "^2.7.6",
+    "@types/argparse": "^2.0.14",
+    "argparse": "^2.0.1",
     "axios": "^1.6.7",
     "discord.js": "^14.14.1",
     "dotenv": "^16.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,32 @@
 // Program entry point.
 
+import { ArgumentParser, Namespace } from "argparse";
+
 import { BotClient } from "./bot/client";
 import env from "./config";
 import getLogger from "./logger";
 
 const log = getLogger(__filename);
 
+const parser = new ArgumentParser({
+  description: "Program entry point for the Discord bot of yung kai world.",
+});
+
+parser.add_argument("--sync", {
+  action: "store_true",
+  help: "deploy slash commands (do not start the bot runtime)",
+});
+parser.add_argument("--stealth", {
+  action: "store_true",
+  help: "start the bot runtime in stealth mode",
+});
+
 async function main() {
-  const stealth = process.argv.includes("--stealth");
+  const args = parser.parse_args() as Namespace;
+  const { sync, stealth } = args;
   const client = new BotClient(stealth);
 
-  if (process.argv.includes("--sync")) {
+  if (sync) {
     log.warning("deploying slash commands only...");
     await client.deploySlashCommands();
     return;


### PR DESCRIPTION
The [argparse](https://www.npmjs.com/package/argparse) library used is a Node.js port of the [Python standard library module of the same name](https://docs.python.org/3/library/argparse.html).

This dependency was already introduced as a development dependency for `scripts/wordnik.js` in #105; it has now been moved to a production dependency to be used by the main program.

This change to using argparse makes the argument parsing logic within `index.ts` more modular, robust, and extendable.