### PR TITLE
Reset and restore mocks before every test

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -36,6 +36,9 @@ const config: Config = {
   // Automatically reset mock state before every test
   resetMocks: true,
 
+  // Automatically restore mock state and implementation before every test
+  restoreMocks: true,
+
   // The root directory that Jest should scan for tests and modules within
   rootDir: "./",
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -6,14 +6,6 @@
 import type { Config } from "jest";
 
 const config: Config = {
-  // All imported modules in your tests should be mocked automatically automock:
-  // false,
-
-  // Stop running tests after `n` failures bail: 0,
-
-  // The directory where Jest should store its cached dependency information
-  // cacheDirectory: "C:\\Users\\vinlin\\AppData\\Local\\Temp\\jest",
-
   // Automatically clear mock calls, instances, contexts and results before
   // every test
   clearMocks: true,
@@ -21,9 +13,6 @@ const config: Config = {
   // Indicates whether the coverage information should be collected while
   // executing the test
   collectCoverage: true,
-
-  // An array of glob patterns indicating a set of files for which coverage
-  // information should be collected collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
   coverageDirectory: "coverage",
@@ -34,9 +23,6 @@ const config: Config = {
     "tests/",
   ],
 
-  // Indicates which provider should be used to instrument code for coverage
-  // coverageProvider: "babel",
-
   // A list of reporter names that Jest uses when writing coverage reports
   coverageReporters: [
     "text", // Display coverage table in stdout
@@ -44,119 +30,22 @@ const config: Config = {
     "json-summary", // Generate JSON data useful for scripting
   ],
 
-  // An object that configures minimum threshold enforcement for coverage
-  // results coverageThreshold: undefined,
-
-  // A path to a custom dependency extractor dependencyExtractor: undefined,
-
-  // Make calling deprecated APIs throw helpful error messages
-  // errorOnDeprecated: false,
-
-  // The default configuration for fake timers fakeTimers: { "enableGlobally":
-  // false
-  // },
-
-  // Force coverage collection from ignored files using an array of glob
-  // patterns forceCoverageMatch: [],
-
-  // A path to a module which exports an async function that is triggered once
-  // before all test suites globalSetup: undefined,
-
-  // A path to a module which exports an async function that is triggered once
-  // after all test suites globalTeardown: undefined,
-
-  // A set of global variables that need to be available in all test
-  // environments globals: {},
-
-  // The maximum amount of workers used to run your tests. Can be specified as %
-  // or a number. E.g. maxWorkers: 10% will use 10% of your CPU amount + 1 as
-  // the maximum worker number. maxWorkers: 2 will use a maximum of 2 workers.
-  // maxWorkers: "50%",
-
-  // An array of directory names to be searched recursively up from the
-  // requiring module's location moduleDirectories: [ "node_modules"
-  // ],
-
-  // An array of file extensions your modules use moduleFileExtensions: [ "js",
-  // "mjs", "cjs", "jsx", "ts", "tsx", "json", "node"
-  // ],
-
-  // A map from regular expressions to module names or to arrays of module names
-  // that allow to stub out resources with a single module moduleNameMapper: {},
-
-  // An array of regexp pattern strings, matched against all module paths before
-  // considered 'visible' to the module loader modulePathIgnorePatterns: [],
-
-  // Activates notifications for test results notify: false,
-
-  // An enum that specifies notification mode. Requires { notify: true }
-  // notifyMode: "failure-change",
-
   // A preset that is used as a base for Jest's configuration
   preset: "ts-jest",
 
-  // Run tests from one or more projects projects: undefined,
-
-  // Use this configuration option to add custom reporters to Jest reporters:
-  // undefined,
-
-  // Automatically reset mock state before every test resetMocks: false,
-
-  // Reset the module registry before running each individual test resetModules:
-  // false,
-
-  // A path to a custom resolver resolver: undefined,
-
-  // Automatically restore mock state and implementation before every test
-  // restoreMocks: false,
+  // Automatically reset mock state before every test
+  resetMocks: true,
 
   // The root directory that Jest should scan for tests and modules within
   rootDir: "./",
 
-  // A list of paths to directories that Jest should use to search for files in
-  // roots: [ "<rootDir>"
-  // ],
-
-  // Allows you to use a custom runner instead of Jest's default test runner
-  // runner: "jest-runner",
-
-  // The paths to modules that run some code to configure or set up the testing
-  // environment before each test setupFiles: [],
-
-  // A list of paths to modules that run some code to configure or set up the
-  // testing framework before each test setupFilesAfterEnv: [],
-
-  // The number of seconds after which a test is considered as slow and reported
-  // as such in the results. slowTestThreshold: 5,
-
-  // A list of paths to snapshot serializer modules Jest should use for snapshot
-  // testing snapshotSerializers: [],
-
   // The test environment that will be used for testing
   testEnvironment: "node",
-
-  // Options that will be passed to the testEnvironment testEnvironmentOptions:
-  // {},
-
-  // Adds a location field to test results testLocationInResults: false,
 
   // The glob patterns Jest uses to detect test files
   testMatch: [
     "<rootDir>/tests/**/*.test.ts",
   ],
-
-  // An array of regexp pattern strings that are matched against all test paths,
-  // matched tests are skipped testPathIgnorePatterns: [ "\\\\node_modules\\\\"
-  // ],
-
-  // The regexp pattern or array of patterns that Jest uses to detect test files
-  // testRegex: [],
-
-  // This option allows the use of a custom results processor
-  // testResultsProcessor: undefined,
-
-  // This option allows use of a custom test runner testRunner:
-  // "jest-circus/runner",
 
   // A map from regular expressions to paths to transformers
   transform: {
@@ -164,23 +53,6 @@ const config: Config = {
       isolatedModules: true, // Skip type checking
     }],
   },
-
-  // An array of regexp pattern strings that are matched against all source file
-  // paths, matched files will skip transformation transformIgnorePatterns: [
-  // "\\\\node_modules\\\\", "\\.pnp\\.[^\\\\]+$"
-  // ],
-
-  // An array of regexp pattern strings that are matched against all modules
-  // before the module loader will automatically return a mock for them
-  // unmockedModulePathPatterns: undefined,
-
-  // Indicates whether each individual test should be reported during the run
-  // verbose: undefined,
-
-  // An array of regexp patterns that are matched against all source file paths
-  // before re-running tests in watch mode watchPathIgnorePatterns: [],
-
-  // Whether to use watchman for file crawling watchman: true,
 };
 
 export default config;

--- a/tests/bot/command.runner.test.ts
+++ b/tests/bot/command.runner.test.ts
@@ -7,6 +7,7 @@ import {
   InteractionReplyOptions,
   RESTPostAPIChatInputApplicationCommandsJSONBody,
 } from "discord.js";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
 
 import * as commandErrors from "../../src/bot/command.errors";
 import { CommandRunner } from "../../src/bot/command.runner";
@@ -17,13 +18,11 @@ import { suppressConsoleError } from "../test-utils";
 function getCommandInteraction(options?: {
   replied?: boolean,
   deferred?: boolean,
-}): ChatInputCommandInteraction {
-  return {
-    replied: !!options?.replied,
-    deferred: !!options?.deferred,
-    reply: jest.fn(),
-    followUp: jest.fn(),
-  } as unknown as ChatInputCommandInteraction;
+}): DeepMockProxy<ChatInputCommandInteraction> {
+  const interaction = mockDeep<ChatInputCommandInteraction>();
+  interaction.replied = !!options?.replied;
+  interaction.deferred = !!options?.deferred;
+  return interaction;
 }
 
 const dummyError = new Error("DUMMY-ERROR");
@@ -57,17 +56,17 @@ describe("run", () => {
   describe("checks", () => {
     const checks: CommandCheck[] = [
       {
-        predicate: jest.fn().mockResolvedValue(true),
+        predicate: jest.fn(),
         onFail: jest.fn(),
         afterExecute: jest.fn(),
       },
       {
-        predicate: jest.fn().mockResolvedValue(true),
+        predicate: jest.fn(),
         onFail: jest.fn(),
         afterExecute: jest.fn(),
       },
       {
-        predicate: jest.fn().mockResolvedValue(true),
+        predicate: jest.fn(),
         onFail: jest.fn(),
         afterExecute: jest.fn(),
       },
@@ -91,7 +90,13 @@ describe("run", () => {
         CommandRunner.prototype as any, // Access protected method.
         "handleCommandError",
       );
+      // Default to predicates returning true (passing).
+      for (const check of checks) {
+        jest.mocked(check.predicate).mockResolvedValue(true);
+      }
     });
+
+    afterAll(() => errorHandlerSpy.mockRestore());
 
     it("should run all checks", async () => {
       await runnerWithChecks.run(interaction);

--- a/tests/bot/command.runner.test.ts
+++ b/tests/bot/command.runner.test.ts
@@ -96,8 +96,6 @@ describe("run", () => {
       }
     });
 
-    afterAll(() => errorHandlerSpy.mockRestore());
-
     it("should run all checks", async () => {
       await runnerWithChecks.run(interaction);
 

--- a/tests/controllers/dev/ping.command.test.ts
+++ b/tests/controllers/dev/ping.command.test.ts
@@ -53,6 +53,4 @@ describe("/ping command", () => {
       content: expect.stringContaining("Latency: **69** ms (nice)"),
     });
   });
-
-  new MockInteraction(pingSpec).testBroadcastOptionSupport();
 });

--- a/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
+++ b/tests/controllers/users/cxtie/timer-reacter.listener.test.ts
@@ -1,14 +1,8 @@
-jest.mock("../../../../src/services/cxtie.service");
-
 import env from "../../../../src/config";
 import randomReacterSpec from "../../../../src/controllers/users/cxtie/timer-reacter.listener";
 import cxtieService from "../../../../src/services/cxtie.service";
 import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
-import { MockMessage, addMockGetter, spyOnRandom } from "../../../test-utils";
-
-const mockedCxtieService = jest.mocked(cxtieService);
-const mockReactChanceGetter = jest.fn();
-addMockGetter(mockedCxtieService, "reactChance", () => mockReactChanceGetter());
+import { MockMessage, spyOnRandom } from "../../../test-utils";
 
 describe("anti-cxtie listener", () => {
   let mock: MockMessage;
@@ -19,7 +13,7 @@ describe("anti-cxtie listener", () => {
 
   describe("should react randomly based on chance computed by service", () => {
     it("should meow", async () => {
-      mockReactChanceGetter.mockReturnValueOnce(0.05);
+      jest.spyOn(cxtieService, "reactChance", "get").mockReturnValueOnce(0.05);
       spyOnRandom().mockReturnValueOnce(0.01);
 
       await mock.simulateEvent();
@@ -28,7 +22,7 @@ describe("anti-cxtie listener", () => {
     });
 
     it("shouldn't react", async () => {
-      mockReactChanceGetter.mockReturnValueOnce(0.05);
+      jest.spyOn(cxtieService, "reactChance", "get").mockReturnValueOnce(0.05);
       spyOnRandom().mockReturnValueOnce(0.42);
 
       await mock.simulateEvent();
@@ -37,7 +31,7 @@ describe("anti-cxtie listener", () => {
     });
 
     it("shouldn't react and then react (dynamic meow chance)", async () => {
-      mockReactChanceGetter
+      jest.spyOn(cxtieService, "reactChance", "get")
         .mockReturnValueOnce(0.05)
         .mockReturnValueOnce(0.95);
       spyOnRandom().mockReturnValue(0.50);

--- a/tests/services/mention-spam.service.test.ts
+++ b/tests/services/mention-spam.service.test.ts
@@ -30,6 +30,7 @@ it("should return false if mentioner exceeds rate limit", async () => {
 });
 
 it("should count mentions to different users independently", async () => {
+  trackerSpy.mockRestore();
   // Reach the rate limit mentioning dummy target 1.
   for (let i = 0; i < 3; i++) {
     mentionSpamService.mentioned(mentioner, mentioned1);

--- a/tests/services/mention-spam.service.test.ts
+++ b/tests/services/mention-spam.service.test.ts
@@ -30,7 +30,6 @@ it("should return false if mentioner exceeds rate limit", async () => {
 });
 
 it("should count mentions to different users independently", async () => {
-  trackerSpy.mockRestore();
   // Reach the rate limit mentioning dummy target 1.
   for (let i = 0; i < 3; i++) {
     mentionSpamService.mentioned(mentioner, mentioned1);

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -230,23 +230,6 @@ export class MockInteraction {
     );
     expect(this.interaction.reply).toHaveBeenCalledTimes(1);
   }
-
-  public async testBroadcastOptionSupport(
-    arrange?: (mock: this) => Awaitable<any>,
-  ) {
-    it("should respond ephemerally by default", async () => {
-      if (arrange) await arrange(this);
-      await this.simulateCommand();
-      this.expectRepliedWith({ ephemeral: true });
-    });
-
-    it("should respond publicly if the broadcast option is set", async () => {
-      if (arrange) await arrange(this);
-      this.mockOption("Boolean", "broadcast", true);
-      await this.simulateCommand();
-      this.expectRepliedWith({ ephemeral: false });
-    });
-  }
 }
 
 export function addMockGetter<ObjectType extends object, ValueType>(
@@ -564,29 +547,6 @@ export async function testBroadcastOptionSupport(
     mock.mockOption("Boolean", "broadcast", true);
     await mock.simulateCommand();
     mock.expectRepliedWith({ ephemeral: false });
-  });
-}
-
-/**
- * Shorthand for running the pair of tests testing the universal `ephemeral`
- * command option. Takes an optional `arrange` callback to properly initialize
- * the `mock` object before each test.
- */
-export async function testEphemeralOptionSupport(
-  mock: MockInteraction,
-  arrange?: (mock: MockInteraction) => Awaitable<any>,
-): Promise<void> {
-  it("should respond publicly by default", async () => {
-    if (arrange) await arrange(mock);
-    await mock.simulateCommand();
-    mock.expectRepliedWith({ ephemeral: false });
-  });
-
-  it("should respond ephemerally if the ephemeral option is set", async () => {
-    if (arrange) await arrange(mock);
-    mock.mockOption("Boolean", "ephemeral", true);
-    await mock.simulateCommand();
-    mock.expectRepliedWith({ ephemeral: true });
   });
 }
 


### PR DESCRIPTION
Closes #85.

Read the commit messages for how I fixed each individual module that was broken.

Other notable notes are that:

* Apparently there's a `restoreMocks` setting in *addition* to `clearMocks` AND `resetMocks`. Apparently `restoreMocks` needs to be used to automatically restore **spies** before each test (I was under the impression that `resetMocks` -- or was it `clearMocks`? one of them -- already did that. Thanks ChatGPT). This resulted in a particularly maddening debugging experience in [Fix command runner tests](https://github.com/vinlin24/yungkaiworldbot/commit/a4337001be3b05dc231b41f389d6cbb005ad2156). Fortunately, simply setting `restoreMocks: true` in `jest.config.ts` after fixing all the `resetMocks: true` errors didn't cause any new errors. **This PR introduces automatic `restoreMocks` in addition to `resetMocks` (#85).**
* `testBroadcastOptionSupport` and `testEphemeralOptionSupport`, while something that would've been nice to have, straight up do not work (the latter of which had been documented in #46). I think I have a better understanding why now. From [Remove test(Broadcast|Ephemeral)OptionSupport](https://github.com/vinlin24/yungkaiworldbot/commit/7c9a67dd5eb6e646f56c6f2ebc4d00f8c27b635b):

> I have to go in and manually add properties on the mock within each it() because for SOME reason the invariants aren't being respected. I think this has something to do with how within each test suite, we would regenerate the MockInteraction or MockMessage with beforeEach(), but within the test...OptionSupport(), we reuse the same mock object, which causes WEIRD behavior.