### PR TITLE
Prune logging statements

### DIFF
--- a/src/bot/client.ts
+++ b/src/bot/client.ts
@@ -99,16 +99,13 @@ export class BotClient extends ClientWithIntentsAndRunnersABC {
     for (const spec of commandSpecs) {
       const commandName = spec.definition.name;
       this.commandRunners.set(commandName, new CommandRunner(spec));
-      log.debug(`imported command module for /${commandName}.`);
     }
   }
 
   private async loadListeners(): Promise<void> {
     const allListenerSpecs = await this.listenerLoader.load(this.stealth);
     for (const spec of allListenerSpecs) {
-      const { id, type } = spec;
-      this.listenerRunners.set(id, new ListenerRunner(spec));
-      log.debug(`imported ${type} listener module ID=${id}.`);
+      this.listenerRunners.set(spec.id, new ListenerRunner(spec));
     }
   }
 

--- a/src/bot/command.loader.ts
+++ b/src/bot/command.loader.ts
@@ -36,10 +36,6 @@ export class CommandLoader {
       // Base case: file is a controller file.
       if (file.endsWith(".command.js") || file.endsWith("command.ts")) {
         commandPaths.push(fullPath);
-        log.debug(
-          "discovered command implementation file: " +
-          `${path.relative(this.commandsBaseDirectoryPath, fullPath)}.`,
-        );
         continue;
       }
     }

--- a/src/bot/command.runner.ts
+++ b/src/bot/command.runner.ts
@@ -75,9 +75,7 @@ export class CommandRunner {
       log.warning(`${context}: no handler to resolve autocomplete.`);
       return;
     }
-    log.debug(`${context}: processing autocomplete.`);
     await this.spec.autocomplete(interaction); // TODO: error handling.
-    log.debug(`${context}: finished processing autocomplete.`);
   }
 
   protected async runChecks(

--- a/src/bot/listener.loader.ts
+++ b/src/bot/listener.loader.ts
@@ -28,7 +28,6 @@ export class ListenerLoader {
     for (const file of contents) {
       const fullPath = path.join(this.specialListenersDirectoryPath, file);
       specialListenerPaths.push(fullPath);
-      log.debug(`discovered special event listener file: ${file}.`);
     }
     return specialListenerPaths;
   }
@@ -52,10 +51,6 @@ export class ListenerLoader {
       // Base case: file is a controller file.
       if (file.endsWith(".listener.js") || file.endsWith("listener.ts")) {
         listenerPaths.push(fullPath);
-        log.debug(
-          "discovered event listener implementation file: " +
-          `${path.relative(this.listenersBaseDirectoryPath, fullPath)}.`,
-        );
         continue;
       }
     }

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -8,11 +8,8 @@ import {
 
 import { CommandRunner } from "../bot/command.runner";
 import { ListenerRunner } from "../bot/listener.runner";
-import getLogger from "../logger";
 import { getCurrentBranchName } from "../utils/meta.utils";
 import { ListenerFilter } from "./listener.types";
-
-const log = getLogger(__filename);
 
 export abstract class ClientWithIntentsAndRunnersABC extends Client {
   public readonly commandRunners
@@ -72,7 +69,7 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
   }
 
   public registerListeners(): void {
-    for (const [id, runner] of this.listenerRunners) {
+    for (const runner of this.listenerRunners.values()) {
       if (runner.spec.type === Events.MessageCreate) {
         this.enforceIgnoreOwnMessages(runner);
       }
@@ -83,7 +80,6 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
       else {
         this.on(runner.spec.type, runner.callbackToRegister);
       }
-      log.debug(`registered event listener '${id}'.`);
     }
   }
 


### PR DESCRIPTION
Closes #113.

Pruned the many **DEBUG** statements related to:

* Bot startup/reloading:
  * Discovery of *each* controller file
  * Importing of *each* controller file
  * Registration of *each* event listener
* `CommandRunner#resolveAutocomplete`: they were never useful, and they fired for EVERY autocomplete interaction, cluttering the logs and possibly slowing down performance with repeated I/O.