### PR TITLE
Exit program on /shutdown success

### DIFF
--- a/src/controllers/dev/shutdown.command.ts
+++ b/src/controllers/dev/shutdown.command.ts
@@ -16,11 +16,22 @@ const slashCommandDefinition = new SlashCommandBuilder()
 
 async function shutdownBot(
   interaction: ChatInputCommandInteraction,
-): Promise<void> {
-  await interaction.reply({ content: "🫡", ephemeral: true });
-  await interaction.client.destroy();
+): Promise<never> {
   const context = formatContext(interaction);
+  try {
+    await interaction.reply({ content: "🫡", ephemeral: true });
+  }
+  // Command should still try to shut down bot no matter what.
+  catch (error) {
+    log.error(`${context}: failed to acknowledge the command.`);
+    console.error(error);
+  }
+
+  await interaction.client.destroy();
   log.info(`${context}: terminated bot runtime.`);
+  // TODO: Is this safe? What if we have teardown code? Should we just use
+  // process.on("exit", ...)?
+  process.exit(0);
 }
 
 const shutdownSpec: CommandSpec = new CommandBuilder()

--- a/tests/controllers/dev/shutdown.command.test.ts
+++ b/tests/controllers/dev/shutdown.command.test.ts
@@ -1,20 +1,38 @@
 import { BABY_MOD_RID } from "../../../src/config";
 import shutdownSpec from "../../../src/controllers/dev/shutdown.command";
-
 import { MockInteraction } from "../../test-utils";
 
 describe("/shutdown command", () => {
+  let exitSpy: jest.SpyInstance<never, [code?: number]>;
+  beforeEach(() => {
+    exitSpy = jest.spyOn(process, "exit").mockImplementation();
+  });
+
   it("should fail if privilege NONE (< BABY_MOD)", async () => {
     const mock = new MockInteraction(shutdownSpec);
+
     await mock.simulateCommand();
+
     expect(mock.interaction.client.destroy).not.toHaveBeenCalled();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   it("should destroy the client if authorized", async () => {
-    const mock = new MockInteraction(shutdownSpec);
-    mock.mockCallerRoles(BABY_MOD_RID);
+    const mock = new MockInteraction(shutdownSpec)
+      .mockCaller({ roleIds: [BABY_MOD_RID] });
+
     await mock.simulateCommand();
+
     expect(mock.interaction.client.destroy).toHaveBeenCalled();
     mock.expectRepliedWith({ content: "🫡" });
+  });
+
+  it("should exit the process with success status code", async () => {
+    const mock = new MockInteraction(shutdownSpec)
+      .mockCaller({ roleIds: [BABY_MOD_RID] });
+
+    await mock.simulateCommand();
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
   });
 });


### PR DESCRIPTION
Loosely related to #110, which also involves bot termination behavior.

Previously, when terminating the bot with /shutdown, the bot instantly goes offline (since `client.destroy()` is called), but the process appears to hang in the terminal. Now we explicitly `process.exit()` at the end of the /shutdown callback.