### PR TITLE
Refactor/interaction utils

### DIFF
--- a/src/middleware/privilege.middleware.ts
+++ b/src/middleware/privilege.middleware.ts
@@ -1,4 +1,8 @@
-import { CommandInteraction, GuildMember, roleMention } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  GuildMember,
+  roleMention,
+} from "discord.js";
 
 import { ALPHA_MOD_RID, BABY_MOD_RID, BOT_DEV_RID, KAI_RID } from "../config";
 import getLogger from "../logger";
@@ -69,12 +73,14 @@ export function checkPrivilege(
     return isAuthorized(memberToCheck);
   }
 
-  function predicate(interaction: CommandInteraction): boolean {
+  function predicate(interaction: ChatInputCommandInteraction): boolean {
     const member = interaction.member as GuildMember;
     return isAuthorized(member);
   }
 
-  async function onFail(interaction: CommandInteraction): Promise<void> {
+  async function onFail(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
     const member = interaction.member as GuildMember;
 
     if (commandLevel === RoleLevel.NONE) { // Pacify LEVEL_TO_RID lookup.

--- a/src/types/handler-proxy.abc.ts
+++ b/src/types/handler-proxy.abc.ts
@@ -1,0 +1,44 @@
+import { ChatInputCommandInteraction, Message } from "discord.js";
+import winston from "winston";
+
+import { formatContext } from "../utils/logging.utils";
+
+/**
+ * Wrapper for some discord.js object to centralize error handling as well as
+ * abstract common operations on it.
+ */
+export abstract class HandlerProxy {
+  constructor(
+    /** discord.js object to wrap. */
+    contextable: ChatInputCommandInteraction | Message,
+    /**
+     * Log to use within this handler. This serves to provide more granular
+     * control over logging. For example, one can provide a child logger when
+     * instantiating the class such that the module name shows up as the
+     * consumer of the handler class.
+     */
+    protected log: winston.Logger,
+  ) {
+    // @ts-expect-error formatContext() literally has overloads specifically for
+    // each type in our union. Unfortunately, we still get ts(2769): "The call
+    // would have succeeded against this implementation, but implementation
+    // signatures of overloads are not externally visible."
+    this.context = formatContext(contextable);
+  }
+
+  /**
+   * The formatted context string of the object the handler is wrapping. This
+   * can be interpolated as a prefix to log statements to provide more
+   * descriptive messages. For example:
+   *
+   *    ```
+   *    this.log.info(`${this.context}: your message here.`);
+   *    ```
+   */
+  protected context: string;
+
+  /**
+   * Centralized custom error handler.
+   */
+  protected abstract handleError(error: Error): void;
+}

--- a/src/types/handler-proxy.abc.ts
+++ b/src/types/handler-proxy.abc.ts
@@ -1,7 +1,6 @@
-import { ChatInputCommandInteraction, Message } from "discord.js";
 import winston from "winston";
 
-import { formatContext } from "../utils/logging.utils";
+import { Contextable, formatContext } from "../utils/logging.utils";
 
 /**
  * Wrapper for some discord.js object to centralize error handling as well as
@@ -10,7 +9,7 @@ import { formatContext } from "../utils/logging.utils";
 export abstract class HandlerProxy {
   constructor(
     /** discord.js object to wrap. */
-    contextable: ChatInputCommandInteraction | Message,
+    contextable: Contextable,
     /**
      * Log to use within this handler. This serves to provide more granular
      * control over logging. For example, one can provide a child logger when

--- a/src/types/listener.types.ts
+++ b/src/types/listener.types.ts
@@ -238,3 +238,10 @@ export class MessageListenerBuilder
 export class DuplicateListenerIDError extends Error {
   constructor(public readonly duplicateId: string) { super(duplicateId); }
 }
+
+/**
+ * Due to the immense popularity of this event type, this type has been
+ * abbreviated.
+ */
+export type MessageListenerExecuteFunction
+  = ListenerExecuteFunction<Events.MessageCreate>;

--- a/src/utils/channel.utils.ts
+++ b/src/utils/channel.utils.ts
@@ -1,0 +1,26 @@
+import { DMChannel, GuildMember, TextChannel } from "discord.js";
+import winston from "winston";
+
+import getLogger from "../logger";
+import { HandlerProxy } from "../types/handler-proxy.abc";
+
+export class TextChannelHandler extends HandlerProxy {
+  constructor(
+    /** The Discord channel to wrap. */
+    public readonly channel: TextChannel,
+    /** The logger to use. */
+    logger?: winston.Logger,
+  ) {
+    super(channel, logger ?? getLogger(__filename));
+  }
+
+  public static async getDMChannel(member: GuildMember): Promise<DMChannel> {
+    return member.dmChannel ?? await member.createDM();
+  }
+
+  protected override handleError(error: Error): void {
+    // TODO: console.error() should be the fallback behavior. Implement an
+    // if-else ladder with specialized behavior for specific types of errors.
+    console.error(error);
+  }
+}

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -12,6 +12,7 @@ import {
 import winston from "winston";
 
 import getLogger from "../logger";
+import { HandlerProxy } from "../types/handler-proxy.abc";
 import { MessageListenerExecuteFunction } from "../types/listener.types";
 import { formatContext } from "./logging.utils";
 
@@ -89,18 +90,15 @@ export async function replyWithGenericACK(
  * Wrapper for a discord.js `ChatInputCommandInteraction` to centralize error
  * handling as well as abstract common operations on interactions.
  */
-export class ChatInputCommandInteractionHandler {
+export class ChatInputCommandInteractionHandler extends HandlerProxy {
   constructor(
     /** The Discord slash command interaction to wrap. */
     public readonly interaction: ChatInputCommandInteraction,
     /* The logger to use. */
     logger?: winston.Logger,
   ) {
-    this.log = logger ?? getLogger(__filename);
+    super(interaction, logger ?? getLogger(__filename));
   }
-
-  private log: winston.Logger;
-  private context = formatContext(this.interaction);
 
   /**
    * Reply to the interaction. This wraps `ChatInputCommandInteraction#reply` by
@@ -138,10 +136,7 @@ export class ChatInputCommandInteractionHandler {
     });
   }
 
-  /**
-   * Centralized custom error handler.
-   */
-  private handleError(error: Error): void {
+  protected override handleError(error: Error): void {
     // TODO: console.error() should be the fallback behavior. Implement an
     // if-else ladder with specialized behavior for specific types of errors.
     console.error(error);

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -2,7 +2,6 @@ import {
   ChatInputCommandInteraction,
   DMChannel,
   EmojiResolvable,
-  Events,
   GuildMember,
   InteractionReplyOptions,
   Message,
@@ -11,7 +10,7 @@ import {
 } from "discord.js";
 
 import getLogger from "../logger";
-import { ListenerExecuteFunction } from "../types/listener.types";
+import { MessageListenerExecuteFunction } from "../types/listener.types";
 import { formatContext } from "./logging.utils";
 
 const log = getLogger(__filename);
@@ -38,7 +37,7 @@ export async function replySilently(
  * `Listener#execute`.
  */
 export function replySilentlyWith(content: string)
-  : ListenerExecuteFunction<Events.MessageCreate> {
+  : MessageListenerExecuteFunction {
   return async (message) => {
     await replySilently(message, content);
     log.debug(`${formatContext(message)}: replied with '${content}'.`);
@@ -50,7 +49,7 @@ export function replySilentlyWith(content: string)
  * to the message with the specified emoji.
  */
 export function reactWith(emoji: EmojiResolvable)
-  : ListenerExecuteFunction<Events.MessageCreate> {
+  : MessageListenerExecuteFunction {
   return async (message) => {
     await message.react(emoji);
     log.debug(`${formatContext(message)}: reacted with ${emoji}.`);
@@ -60,7 +59,7 @@ export function reactWith(emoji: EmojiResolvable)
 /**
  * Silently reply to the message with the message's own content.
  */
-export const echoContent: ListenerExecuteFunction<Events.MessageCreate>
+export const echoContent: MessageListenerExecuteFunction
   = async function (message) {
     await replySilently(message, message.content);
     log.debug(`${formatContext(message)}: echoed '${message.content}'.`);

--- a/src/utils/interaction.utils.ts
+++ b/src/utils/interaction.utils.ts
@@ -21,6 +21,8 @@ const log = getLogger(__filename);
 /**
  * Wrapper for the boilerplate of replying to a `Message` with the `@silent`
  * setting and without pinging anyone.
+ *
+ * @deprecated Use `MessageHandler`.
  */
 export async function replySilently(
   message: Message,
@@ -38,6 +40,8 @@ export async function replySilently(
 /**
  * Same as `replySilently` but return a closure that can be passed directly to
  * `Listener#execute`.
+ *
+ * @deprecated Use `MessageHandler`.
  */
 export function replySilentlyWith(content: string)
   : MessageListenerExecuteFunction {
@@ -50,6 +54,8 @@ export function replySilentlyWith(content: string)
 /**
  * Return a closure that can be passed directly to `Listener#execute`. Reacts
  * to the message with the specified emoji.
+ *
+ * @deprecated Use `MessageHandler`.
  */
 export function reactWith(emoji: EmojiResolvable)
   : MessageListenerExecuteFunction {
@@ -61,6 +67,8 @@ export function reactWith(emoji: EmojiResolvable)
 
 /**
  * Silently reply to the message with the message's own content.
+ *
+ * @deprecated Use `MessageHandler`.
  */
 export const echoContent: MessageListenerExecuteFunction
   = async function (message) {
@@ -70,11 +78,16 @@ export const echoContent: MessageListenerExecuteFunction
 
 /**
  * Get the DM channel of a member.
+ *
+ * @deprecated Use `TextChannelHandler`.
  */
 export async function getDMChannel(member: GuildMember): Promise<DMChannel> {
   return member.dmChannel ?? await member.createDM();
 }
 
+/**
+ * @deprecated Use `ChatInputCommandInteractionHandler`.
+ */
 export async function replyWithGenericACK(
   interaction: ChatInputCommandInteraction,
   options?: Omit<InteractionReplyOptions, "content">,

--- a/src/utils/logging.utils.ts
+++ b/src/utils/logging.utils.ts
@@ -1,12 +1,12 @@
 import {
   AutocompleteInteraction,
-  CommandInteraction,
+  ChatInputCommandInteraction,
   GuildTextBasedChannel,
   Message,
 } from "discord.js";
 
 export function formatContext(message: Message): string;
-export function formatContext(interaction: CommandInteraction): string;
+export function formatContext(interaction: ChatInputCommandInteraction): string;
 export function formatContext(interaction: AutocompleteInteraction): string;
 
 /**
@@ -21,7 +21,7 @@ export function formatContext(interaction: AutocompleteInteraction): string;
  * TODO: Not sure if there's a way to automate this through Winston.
  */
 export function formatContext(
-  obj: Message | CommandInteraction | AutocompleteInteraction,
+  obj: Message | ChatInputCommandInteraction | AutocompleteInteraction,
 ): string {
   if (obj instanceof Message) {
     const message = obj;

--- a/src/utils/logging.utils.ts
+++ b/src/utils/logging.utils.ts
@@ -3,11 +3,25 @@ import {
   ChatInputCommandInteraction,
   GuildTextBasedChannel,
   Message,
+  TextChannel,
 } from "discord.js";
+
+// TODO: These types seem to be coupled with the functionality of HandlerProxy.
+// Since we make these handler classes to abstract the handling of these
+// discord.js objects in the first place, maybe we can deprecate formatContext()
+// here later and make it an implementation detail and responsibility of
+// HandlerProxy.
+export type Contextable =
+  | Message
+  | ChatInputCommandInteraction
+  | AutocompleteInteraction
+  | TextChannel
+  ;
 
 export function formatContext(message: Message): string;
 export function formatContext(interaction: ChatInputCommandInteraction): string;
 export function formatContext(interaction: AutocompleteInteraction): string;
+export function formatContext(channel: TextChannel): string;
 
 /**
  * Return a formatted string containing the relevant information about a
@@ -20,14 +34,16 @@ export function formatContext(interaction: AutocompleteInteraction): string;
  *
  * TODO: Not sure if there's a way to automate this through Winston.
  */
-export function formatContext(
-  obj: Message | ChatInputCommandInteraction | AutocompleteInteraction,
-): string {
+export function formatContext(obj: Contextable): string {
   if (obj instanceof Message) {
     const message = obj;
     const authorName = message.author.username;
     const channelName = (message.channel as GuildTextBasedChannel).name;
     return `@${authorName} <MSG> #${channelName}`;
+  }
+  if (obj instanceof TextChannel) {
+    const channel = obj;
+    return `#${channel.name}`;
   }
   const interaction = obj;
   const commandName = interaction.commandName;

--- a/src/utils/message.utils.ts
+++ b/src/utils/message.utils.ts
@@ -1,0 +1,139 @@
+import {
+  EmojiIdentifierResolvable,
+  Message,
+  MessageCreateOptions,
+  MessageFlags,
+  MessageReaction,
+} from "discord.js";
+import winston from "winston";
+
+import getLogger from "../logger";
+import { MessageListenerExecuteFunction } from "../types/listener.types";
+import { formatContext } from "./logging.utils";
+
+/**
+ * Wrapper for a discord.js `Message` to centralize error handling as well as
+ * abstract common operations on messages.
+ */
+export class MessageHandler {
+  constructor(
+    /** The Discord message to wrap. */
+    public readonly message: Message,
+    /* The logger to use. */
+    logger?: winston.Logger,
+  ) {
+    this.log = logger ?? getLogger(__filename);
+  }
+
+  private log: winston.Logger;
+  private context = formatContext(this.message);
+
+  /**
+   * Reply to the message. This wraps `Message#reply` by providing our own
+   * centralized, custom error handling.
+   */
+  public async reply(
+    options: string | MessageCreateOptions,
+  ): Promise<Message | null> {
+    try {
+      return await this.message.reply(options);
+    }
+    catch (error) {
+      this.log.error(
+        `${this.context}: failed to reply to message ${this.message.url}.`,
+      );
+      this.handleError(error as Error);
+      return null;
+    }
+  }
+
+  /**
+   * Wrapper for the boilerplate of replying to a `Message` with the `@silent`
+   * setting and without pinging anyone.
+   */
+  public async replySilently(
+    options: string | MessageCreateOptions,
+  ): Promise<Message | null> {
+    let payload = typeof options === "string" ? { options } : options;
+    payload = {
+      ...payload,
+      allowedMentions: { repliedUser: false, parse: [] },
+      flags: MessageFlags.SuppressNotifications,
+    };
+    return await this.reply(payload);
+  }
+
+  /**
+   * Same as `replySilently` but return a closure that can be passed directly to
+   * `Listener#execute`.
+   */
+  public static replySilentlyWith(
+    options: string | MessageCreateOptions,
+    logger?: winston.Logger,
+  ): MessageListenerExecuteFunction {
+    return async message => {
+      await new MessageHandler(message, logger).replySilently(options);
+    };
+  }
+
+  /**
+   * Reacts to the message with the specified emoji. This wraps `Message#react`
+   * by providing our own centralized, custom error handling.
+   */
+  public async react(
+    emoji: EmojiIdentifierResolvable,
+  ): Promise<MessageReaction | null> {
+    try {
+      return await this.message.react(emoji);
+    }
+    catch (error) {
+      this.log.error(
+        `${this.context}: failed to react with ${emoji} ` +
+        `to message ${this.message.url}.`,
+      );
+      this.handleError(error as Error);
+      return null;
+    }
+  }
+
+  /**
+   * Same as `react` but return a closure that can be passed directly to
+   * `Listener#execute`.
+   */
+  public static reactWith(
+    emoji: EmojiIdentifierResolvable,
+    logger?: winston.Logger,
+  ): MessageListenerExecuteFunction {
+    return async message => {
+      await new MessageHandler(message, logger).react(emoji);
+    };
+  }
+
+  /**
+   * Simply echo the message's content. This replies silently.
+   */
+  public async echo(): Promise<Message | null> {
+    return await this.replySilently(this.message.content);
+  }
+
+  /**
+   * Same as `echo` but return a closure that can be passed directly to
+   * `Listener#execute`.
+   */
+  public static echoContent(
+    logger?: winston.Logger,
+  ): MessageListenerExecuteFunction {
+    return async message => {
+      await new MessageHandler(message, logger).echo();
+    };
+  }
+
+  /**
+   * Centralized custom error handler.
+   */
+  private handleError(error: Error): void {
+    // TODO: console.error() should be the fallback behavior. Implement an
+    // if-else ladder with specialized behavior for specific types of errors.
+    console.error(error);
+  }
+}

--- a/src/utils/message.utils.ts
+++ b/src/utils/message.utils.ts
@@ -8,25 +8,22 @@ import {
 import winston from "winston";
 
 import getLogger from "../logger";
+import { HandlerProxy } from "../types/handler-proxy.abc";
 import { MessageListenerExecuteFunction } from "../types/listener.types";
-import { formatContext } from "./logging.utils";
 
 /**
  * Wrapper for a discord.js `Message` to centralize error handling as well as
  * abstract common operations on messages.
  */
-export class MessageHandler {
+export class MessageHandler extends HandlerProxy {
   constructor(
     /** The Discord message to wrap. */
     public readonly message: Message,
     /* The logger to use. */
     logger?: winston.Logger,
   ) {
-    this.log = logger ?? getLogger(__filename);
+    super(message, logger ?? getLogger(__filename));
   }
-
-  private log: winston.Logger;
-  private context = formatContext(this.message);
 
   /**
    * Reply to the message. This wraps `Message#reply` by providing our own
@@ -128,10 +125,7 @@ export class MessageHandler {
     };
   }
 
-  /**
-   * Centralized custom error handler.
-   */
-  private handleError(error: Error): void {
+  protected override handleError(error: Error): void {
     // TODO: console.error() should be the fallback behavior. Implement an
     // if-else ladder with specialized behavior for specific types of errors.
     console.error(error);


### PR DESCRIPTION
## Overview

This PR refactors the helper functions in `interaction.utils.ts` into classes that wrap their respective discord.js objects:

* `Message` -> `MessageHandler`
* `ChatInputCommandInteraction` -> `ChatInputCommandInteractionHandler`
* `TextChannel` -> `TextChannelHandler`

These three classes inherit from a new ABC, `HandlerProxy`. The goal with these classes is to centralize custom error handling as well as abstract common operations on messages, interactions, etc.

How existing code or code going forward would look like (from `timeout-proxy.command.ts` as an example -- it's unchanged in this PR):
 
```diff
-  await replyWithGenericACK(interaction, { ephemeral: true }); // Stealth :)
+  const handler = new ChatInputCommandInteractionHandler(interaction, log);
+  await handler.replyWithGenericACK({ ephemeral: true }); // Stealth :)
   return true;
```

For backwards compatibility (it would be a massive change to refactor all existing instances), the original helper functions have not been removed; rather, they have just been marked `@deprecated`. 

## Concerns

> [!NOTE]
> I'm still unsure about the architectural design choices/flaws about this approach, so I think I'll sit on this PR for a bit first.

Notably, from the commit message of [Add TextChannelHandler](https://github.com/vinlin24/yungkaiworldbot/commit/b3389ac9b9847e23282697ad35d72215dfc2115e):

```
This was just to have a class for the last function remaining to be
refactored, `getDMChannel`.

Creating this class at all feels kind of forced with how we set up
HandlerProxy. Namely, it meant extending formatContext() to handle a
TextChannel overload, which may or may not make sense.

Furthermore, this is indicative of a potential architectural flaw.
formatContext() and HandlerProxy seem very coupled despite being in
completely separate modules. Since we make these handler classes to
abstract the handling of these discord.js objects in the first place,
maybe we can deprecate the original formatContext() later and move it to
be an implementation detail and responsibility of HandlerProxy.
```

Another concern is verbosity: is turning every `reply` line into two worth the abstraction? Most of them would just be instantiating the class just to call a single method on it anyway, so there's also the concern of runtime overhead.