### PR TITLE
Support /react'ing with multiple emojis in one go

### DIFF
--- a/src/controllers/dev/control/react.command.ts
+++ b/src/controllers/dev/control/react.command.ts
@@ -1,14 +1,25 @@
-import { SlashCommandBuilder } from "discord.js";
+import {
+  ChatInputCommandInteraction,
+  EmojiIdentifierResolvable,
+  Message,
+  SlashCommandBuilder,
+  inlineCode,
+} from "discord.js";
 
+import getLogger from "../../../logger";
 import {
   RoleLevel,
   checkPrivilege,
 } from "../../../middleware/privilege.middleware";
 import { CommandBuilder } from "../../../types/command.types";
+import { extractAllEmojis } from "../../../utils/emojis.utils";
+import { formatContext } from "../../../utils/logging.utils";
 import {
   fetchNthMostRecentMessage,
   resolveMessageToRespondTo,
 } from "./dev-control-utils";
+
+const log = getLogger(__filename);
 
 const devReact = new CommandBuilder();
 
@@ -16,8 +27,8 @@ devReact.define(new SlashCommandBuilder()
   .setName("react")
   .setDescription("Make the bot react to an existing message.")
   .addStringOption(input => input
-    .setName("emoji")
-    .setDescription("Emoji to react with.")
+    .setName("emojis")
+    .setDescription("Emoji(s) to react with.")
     .setRequired(true),
   )
   .addStringOption(input => input
@@ -31,8 +42,17 @@ devReact.define(new SlashCommandBuilder()
 
 devReact.check(checkPrivilege(RoleLevel.DEV));
 devReact.execute(async interaction => {
-  const emoji = interaction.options.getString("emoji", true);
+  const inputString = interaction.options.getString("emojis", true);
   const messageId = interaction.options.getString("message");
+
+  const emojis = extractAllEmojis(inputString);
+  if (emojis.length === 0) {
+    await interaction.reply({
+      content: `No emojis found in your input ${inlineCode(inputString)}!`,
+      ephemeral: true,
+    });
+    return false;
+  }
 
   let message = await resolveMessageToRespondTo(interaction, messageId);
   // resolveMessageToRespondTo already replies about error.
@@ -42,22 +62,67 @@ devReact.execute(async interaction => {
   }
   if (message === null) return false;
 
-  try {
-    await message.react(emoji);
+  const success = await reactWithEmojisAndReplyToInteraction(
+    message,
+    emojis,
+    interaction,
+  );
+  return success;
+});
+
+async function reactWithEmojisAndReplyToInteraction(
+  message: Message,
+  emojis: EmojiIdentifierResolvable[],
+  interaction: ChatInputCommandInteraction,
+): Promise<boolean> {
+  const context = formatContext(interaction);
+
+  const succeededEmojis: EmojiIdentifierResolvable[] = [];
+  const failedEmojis: EmojiIdentifierResolvable[] = [];
+
+  for (const emoji of emojis) {
+    try {
+      await message.react(emoji);
+      succeededEmojis.push(emoji);
+    }
+    catch (error) {
+      failedEmojis.push(emoji);
+    }
   }
-  catch (error) {
+
+  if (succeededEmojis.length > 0) {
+    log.info(
+      `${context}: reacted with ${succeededEmojis.join(", ")} ` +
+      `on ${message.url}.`,
+    );
+  }
+
+  if (failedEmojis.length > 0) {
+    log.warning(
+      `${context}: failed to react with ${failedEmojis.join(", ")} ` +
+      `on ${message.url}.`,
+    );
+
+    const formattedFailedEmojis = failedEmojis
+      .map(emoji => inlineCode(emoji as string))
+      .join(", ");
+
     await interaction.reply({
       content:
-        `Failed to react with \`${emoji}\`. ` +
-        "Are you sure this is a valid emoji?",
+        `Failed to react with emojis: ${formattedFailedEmojis}. ` +
+        "Are you sure these are valid emojis?",
       ephemeral: true,
     });
+
     return false;
   }
 
-  await interaction.reply({ content: "👍", ephemeral: true });
+  await interaction.reply({
+    content: `✅ Reacted with ${succeededEmojis.join(" ")}`,
+    ephemeral: true,
+  });
   return true;
-});
+}
 
 const devReactSpec = devReact.toSpec();
 export default devReactSpec;

--- a/src/utils/emojis.utils.ts
+++ b/src/utils/emojis.utils.ts
@@ -1,3 +1,5 @@
+import { EmojiIdentifierResolvable } from "discord.js";
+
 export type CustomEmoji = {
   name: string;
   id: string;
@@ -28,6 +30,15 @@ export function toEscapedEmoji(emoji: CustomEmoji): string {
   // Animated emojis take the form of <a:NAME:ID>. Non-animated emojis take the
   // form of <:NAME:ID>.
   return `<${animated ? "a" : ""}:${name}:${id}>`;
+}
+
+/**
+ * Extract and return all Unicode and custom emojis from a string
+ */
+export function extractAllEmojis(input: string): EmojiIdentifierResolvable[] {
+  const emojiRegex = /(\p{Emoji_Presentation}|<a?:.+?:\d+?>)/gu;
+  const matches = input.match(emojiRegex);
+  return matches ?? [];
 }
 
 // TODO: Should these only store IDs or full CustomEmoji objects?

--- a/tests/controllers/dev/control/react.command.test.ts
+++ b/tests/controllers/dev/control/react.command.test.ts
@@ -1,4 +1,4 @@
-import { Collection, Message } from "discord.js";
+import { Collection, Message, inlineCode } from "discord.js";
 import { mockDeep } from "jest-mock-extended";
 
 import { BOT_DEV_RID, KAI_RID } from "../../../../src/config";
@@ -10,13 +10,22 @@ import {
   mockChannelFetchMessageById,
 } from "./dev-control-test-utils";
 
+const dummyMessageId = "123456789";
+
 let mock: MockInteraction;
 beforeEach(() => { mock = new MockInteraction(devReactSpec); });
+
+function expectRepliedWithSucceededEmojis(...emojis: string[]): void {
+  mock.expectRepliedWith({
+    content: expect.stringContaining(`✅ Reacted with ${emojis.join(" ")}`),
+    ephemeral: true,
+  });
+}
 
 it("should require privilege level >= DEV", async () => {
   mock
     .mockCaller({ roleIds: [KAI_RID] })
-    .mockOption("String", "emoji", "🥺");
+    .mockOption("String", "emojis", "🥺");
   await mock.simulateCommand();
   expect(mock.interaction.channel!.messages.fetch).not.toHaveBeenCalled();
   mock.expectMentionedMissingPrivilege(RoleLevel.DEV);
@@ -25,7 +34,7 @@ it("should require privilege level >= DEV", async () => {
 it("should react to the most recent message", async () => {
   mock
     .mockCaller({ roleIds: [BOT_DEV_RID] })
-    .mockOption("String", "emoji", "🤩");
+    .mockOption("String", "emojis", "🤩");
   const mockMessage = mockDeep<Message<true>>();
   mock.interaction.channel!.messages.fetch
     .mockResolvedValueOnce(new Collection([["DUMMY-ID", mockMessage]]));
@@ -33,43 +42,41 @@ it("should react to the most recent message", async () => {
   await mock.simulateCommand();
 
   expect(mockMessage.react).toHaveBeenCalledWith("🤩");
-  mock.expectRepliedGenericACK();
+  expectRepliedWithSucceededEmojis("🤩");
 });
 
 it("should react to the specified message (using ID)", async () => {
-  const dummyMessageId = "123456789";
   mock
     .mockCaller({ roleIds: [BOT_DEV_RID] })
-    .mockOption("String", "emoji", "🫡")
+    .mockOption("String", "emojis", "🫡")
     .mockOption("String", "message", dummyMessageId);
   const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
 
   await mock.simulateCommand();
 
   expect(mockMessage.react).toHaveBeenCalledWith("🫡");
-  mock.expectRepliedGenericACK();
+  expectRepliedWithSucceededEmojis("🫡");
 });
 
 it("should react to the specified message (using URL)", async () => {
-  const dummyMessageId = "123456789";
   const dummyUrl = `https://discord.com/channels/3344/6677/${dummyMessageId}`;
   mock
     .mockCaller({ roleIds: [BOT_DEV_RID] })
-    .mockOption("String", "emoji", "😪")
+    .mockOption("String", "emojis", "😪")
     .mockOption("String", "message", dummyUrl);
   const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
 
   await mock.simulateCommand();
 
   expect(mockMessage.react).toHaveBeenCalledWith("😪");
-  mock.expectRepliedGenericACK();
+  expectRepliedWithSucceededEmojis("😪");
 });
 
 describe("caret notation", () => {
   beforeEach(() => {
     mock
       .mockCaller({ roleIds: [BOT_DEV_RID] })
-      .mockOption("String", "emoji", "🔥");
+      .mockOption("String", "emojis", "🔥");
   });
 
   it("should react to the 3rd most recent message (by ^^^)", async () => {
@@ -79,7 +86,7 @@ describe("caret notation", () => {
     await mock.simulateCommand();
 
     expect(mockMessage.react).toHaveBeenCalledWith("🔥");
-    mock.expectRepliedGenericACK();
+    expectRepliedWithSucceededEmojis("🔥");
   });
 
   it("should react to the 3rd most recent message (by ^3)", async () => {
@@ -89,7 +96,7 @@ describe("caret notation", () => {
     await mock.simulateCommand();
 
     expect(mockMessage.react).toHaveBeenCalledWith("🔥");
-    mock.expectRepliedGenericACK();
+    expectRepliedWithSucceededEmojis("🔥");
   });
 });
 
@@ -97,14 +104,16 @@ describe("error handling", () => {
   it("should reject invalid emojis", async () => {
     mock
       .mockCaller({ roleIds: [BOT_DEV_RID] })
-      .mockOption("String", "emoji", "😨");
+      .mockOption("String", "emojis", "😨");
     const mockMessage = mockChannelFetchMessage(mock);
     mockMessage.react.mockRejectedValueOnce("DUMMY-ERROR");
 
     await mock.simulateCommand();
 
     mock.expectRepliedWith({
-      content: expect.stringContaining("Failed to react with `😨`"),
+      content: expect.stringContaining(
+        `Failed to react with emojis: ${inlineCode("😨")}.`,
+      ),
       ephemeral: true,
     });
   });
@@ -112,7 +121,7 @@ describe("error handling", () => {
   it("should reject invalid message identifiers", async () => {
     mock
       .mockCaller({ roleIds: [BOT_DEV_RID] })
-      .mockOption("String", "emoji", "😨")
+      .mockOption("String", "emojis", "😨")
       .mockOption("String", "message", "lmao");
 
     await mock.simulateCommand();


### PR DESCRIPTION
Closes #119.

**Changes**

* Changed `/react` option name: `emoji` -> `emojis`
* The `emojis` string option now supports an arbitrary string instead of just a single emoji. The entire string input is then parsed, and all emojis (both Unicode and custom) are extracted, and those are what are used to react to the target message.
  * If no emojis were detected, no reaction happens, and the command counts as a failure.
  * If the bot failed to react with one or more of the emojis, the bot will still try to react with the remaining emojis. The failed emojis are collected and displayed as an error notification in the interaction reply.
  * If all emojis reactions are successful, the bot replies with a list of the emojis reacted (instead of the generic ACK from before).

**Todos/Warnings**

At the moment, a "reaction failure" is implemented with a general `try`-`catch`. It does not account for specific types of errors, such as Discord API errors like 50007 Reaction Blocked (#102). This means that if, for example, `/react` attempts to react to a message from a user that blocked the bot, the reaction(s) will fail and the bot will claim that it's because the emoji(s) are invalid, which is a bit misleading.

Because `/react` is a **DEV** privilege command, this isn't a big issue at the present moment, but it is indicative of an architecture flaw. That is, we should have a way to centralize error handling on all presentation layer actions (replying to interactions/messages, reacting to messages, etc.). #118 attempts to start on this.