### PR TITLE
Trigger tempbot appreciation on tempbotNI

### DIFF
--- a/src/controllers/users/ni/tempbot-appreciation.listener.ts
+++ b/src/controllers/users/ni/tempbot-appreciation.listener.ts
@@ -6,7 +6,9 @@ import { reactWith } from "../../../utils/interaction.utils";
 const tempbotAppreciation = new MessageListenerBuilder()
   .setId("tempbot-appreciation");
 
-tempbotAppreciation.filter(contentMatching(/\btempbot appreciation\b/i));
+const regex = /\btempbot([*_]*ni[*_]*)? appreciation\b/i;
+
+tempbotAppreciation.filter(contentMatching(regex));
 tempbotAppreciation.execute(reactWith(GUILD_EMOJIS.NEKO_UWU));
 
 const tempbotAppreciationSpec = tempbotAppreciation.toSpec();

--- a/tests/controllers/users/ni/tempbot-appreciation.listener.test.ts
+++ b/tests/controllers/users/ni/tempbot-appreciation.listener.test.ts
@@ -1,3 +1,5 @@
+import { bold } from "discord.js";
+
 import tempbotAppreciationSpec from "../../../../src/controllers/users/ni/tempbot-appreciation.listener";
 import { GUILD_EMOJIS } from "../../../../src/utils/emojis.utils";
 import { MockMessage } from "../../../test-utils";
@@ -5,6 +7,13 @@ import { MockMessage } from "../../../test-utils";
 it("should react with neko uwu upon appreciation", async () => {
   const mock = new MockMessage(tempbotAppreciationSpec)
     .mockContent("daily tempbot appreciation");
+  await mock.simulateEvent();
+  mock.expectReactedWith(GUILD_EMOJIS.NEKO_UWU);
+});
+
+it("should still trigger on 'tempbotni', with possible markup", async () => {
+  const mock = new MockMessage(tempbotAppreciationSpec)
+    .mockContent(`DAILY TEMPBOT${bold("NI")} APPRECIATION`);
   await mock.simulateEvent();
   mock.expectReactedWith(GUILD_EMOJIS.NEKO_UWU);
 });


### PR DESCRIPTION
Minor tweak to the `tempbot-appreciation` listener (#68). Users like Ni often append the **NI** suffix to names e.g. "DAILY TEMPBOT**NI** APPRECIATION". The trigger regex has been enhanced to cover this case.