### PR TITLE
Add mode for copying dev reactions

### DIFF
--- a/src/controllers/dev/control/concerted-react.listener.ts
+++ b/src/controllers/dev/control/concerted-react.listener.ts
@@ -1,0 +1,89 @@
+import {
+  Events,
+  Message,
+  MessageReaction,
+  PartialMessageReaction,
+  PartialUser,
+  User,
+} from "discord.js";
+
+import { BOT_DEV_RID, YUNG_KAI_WORLD_GID } from "../../../config";
+import getLogger from "../../../logger";
+import devControlService from "../../../services/dev-control.service";
+import { ListenerBuilder } from "../../../types/listener.types";
+import { formatContext } from "../../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+const concertedReact = new ListenerBuilder(Events.MessageReactionAdd)
+  .setId("concerted-react");
+
+concertedReact.filter(() => devControlService.reactWithDev);
+concertedReact.filter(isDevThatReacted);
+concertedReact.execute(async (reaction, user) => {
+  const { message, emoji } = reaction;
+  await message.react(emoji);
+
+  const context = formatContext(message as Message);
+  log.info(`${context}: concerted reaction ${emoji} with @${user.username}.`);
+  return true;
+});
+
+/**
+ * Check if the reaction is a partial structure, and if so, resolve it such that
+ * the message associated with it is in a well-defined stated after this call.
+ * Return whether the resolution succeeded.
+ *
+ * TODO: This checking comes from the discord.js documentation
+ * https://discordjs.guide/popular-topics/reactions.html and is likely common to
+ * all reaction event listeners, so this may need to be promoted to utils.
+ */
+async function resolvePartialReaction(
+  reaction: MessageReaction | PartialMessageReaction,
+  // Would be nice to use something like Promise<reaction is MessageReaction>,
+  // but this syntax isn't supported in TypeScript yet.
+): Promise<boolean> {
+  if (reaction.partial) {
+    // If the message this reaction belongs to was removed, the fetching might
+    // result in an API error which should be handled
+    try {
+      await reaction.fetch();
+    }
+    catch (error) {
+      log.error("something went wrong fetching partial reaction's message.");
+      console.error(error);
+      // Return as `reaction.message.author` may be undefined/null.
+      return false;
+    }
+  }
+  return true;
+}
+
+async function isDevThatReacted(
+  reaction: MessageReaction | PartialMessageReaction,
+  user: User | PartialUser,
+): Promise<boolean> {
+  if (!await resolvePartialReaction(reaction)) return false;
+  reaction = reaction as MessageReaction;
+  const context = formatContext(reaction.message as Message);
+
+  const guild = reaction.client.guilds.cache.get(YUNG_KAI_WORLD_GID);
+  if (!guild) {
+    log.warning(
+      `${context}: failed to get cached guild from ID=${YUNG_KAI_WORLD_GID}.`,
+    );
+    return false;
+  }
+
+  const member = guild.members.cache.get(user.id);
+  if (!member) {
+    log.warning(`${context}: failed to get cached member from ID=${user.id}.`);
+    return false;
+  }
+
+  const hasBotDevRole = member.roles.cache.has(BOT_DEV_RID);
+  return hasBotDevRole;
+}
+
+const concertedReactSpec = concertedReact.toSpec();
+export default concertedReactSpec;

--- a/src/controllers/dev/control/set-concerted-react.command.ts
+++ b/src/controllers/dev/control/set-concerted-react.command.ts
@@ -1,0 +1,40 @@
+import { SlashCommandBuilder, bold } from "discord.js";
+
+import getLogger from "../../../logger";
+import {
+  RoleLevel,
+  checkPrivilege,
+} from "../../../middleware/privilege.middleware";
+import devControlService from "../../../services/dev-control.service";
+import { CommandBuilder } from "../../../types/command.types";
+import { formatContext } from "../../../utils/logging.utils";
+
+const log = getLogger(__filename);
+
+const setConcertedReact = new CommandBuilder();
+
+setConcertedReact.define(new SlashCommandBuilder()
+  .setName("set-concerted-react")
+  .setDescription("Set whether the bot should copy dev reactions.")
+  .addBooleanOption(input => input
+    .setName("enabled")
+    .setDescription("Whether this feature is enabled.")
+    .setRequired(true),
+  ),
+);
+
+setConcertedReact.check(checkPrivilege(RoleLevel.DEV));
+setConcertedReact.execute(async interaction => {
+  const enabled = interaction.options.getBoolean("enabled", true);
+  devControlService.reactWithDev = enabled;
+
+  log.info(`${formatContext(interaction)}: set reactWithDev=${enabled}.`);
+  await interaction.reply({
+    ephemeral: true,
+    content:
+      `${bold(enabled ? "Enabled" : "Disabled")} concerted DEV reactions.`,
+  });
+});
+
+const setConcertedReactSpec = setConcertedReact.toSpec();
+export default setConcertedReactSpec;

--- a/src/services/dev-control.service.ts
+++ b/src/services/dev-control.service.ts
@@ -1,0 +1,6 @@
+export class DevControlService {
+  /** Whether the bot should perform concerted reactions with DEV reactions. */
+  public reactWithDev: boolean = false;
+}
+
+export default new DevControlService();

--- a/src/types/client.abc.ts
+++ b/src/types/client.abc.ts
@@ -4,6 +4,7 @@ import {
   Events,
   GatewayIntentBits,
   Message,
+  Partials,
 } from "discord.js";
 
 import { CommandRunner } from "../bot/command.runner";
@@ -39,6 +40,12 @@ export abstract class ClientWithIntentsAndRunnersABC extends Client {
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.GuildModeration,
         GatewayIntentBits.DirectMessages,
+        GatewayIntentBits.GuildMessageReactions,
+      ],
+      // https://discordjs.guide/popular-topics/partials.html#enabling-partials.
+      partials: [
+        Partials.Message,
+        Partials.Reaction,
       ],
     });
     this.setMaxListeners(Infinity); // Pacify warning.

--- a/tests/controllers/dev/control/concerted-react.listener.test.ts
+++ b/tests/controllers/dev/control/concerted-react.listener.test.ts
@@ -1,0 +1,116 @@
+import {
+  Guild,
+  GuildMember,
+  MessageReaction,
+  ReactionEmoji,
+  User,
+} from "discord.js";
+import { DeepMockProxy, mockDeep } from "jest-mock-extended";
+
+import { ListenerRunner } from "../../../../src/bot/listener.runner";
+import { BOT_DEV_RID, YUNG_KAI_WORLD_GID } from "../../../../src/config";
+import concertedReactSpec from "../../../../src/controllers/dev/control/concerted-react.listener";
+import devControlService from "../../../../src/services/dev-control.service";
+import { addMockGetter } from "../../../test-utils";
+
+let mockReaction: DeepMockProxy<MessageReaction>;
+let mockUser: DeepMockProxy<User>;
+beforeEach(() => {
+  mockReaction = mockDeep<MessageReaction>();
+  mockUser = mockDeep<User>();
+});
+
+/**
+ * ARRANGE.
+ *
+ * Arrange the mock reaction and mock user to emit (the objects passed to the
+ * `MessageReactionAdd` event listener pipeline).
+ */
+function arrangeEmission(options: {
+  enabled: boolean,
+  reacterIsDev?: boolean,
+  emoji?: string,
+}): void {
+  // Mock service state.
+  jest.replaceProperty(devControlService, "reactWithDev", options.enabled);
+
+  // Mock emoji getting.
+  const mockEmoji = mockDeep<ReactionEmoji>();
+  addMockGetter(mockEmoji, "identifier", options.emoji ?? "❤️");
+  addMockGetter(mockReaction, "emoji", mockEmoji);
+
+  // Mock ID of reacter.
+  const mockReacterId = "1234";
+  mockUser.id = mockReacterId;
+
+  // MOCKING THE REACTION
+  // --------------------
+  // To check if it was a dev that reacted, we need to interrogate the
+  // reaction's guild -> getting the member from user in that guild -> checking
+  // that member's roles.
+
+  // (1) Mock guild getting.
+  const mockGuild = mockDeep<Guild>();
+  mockReaction.client.guilds.cache.get
+    .calledWith(YUNG_KAI_WORLD_GID)
+    .mockReturnValue(mockGuild);
+
+  // (2) Mock member getting.
+  mockGuild.members.cache.get.mockImplementation(key => {
+    if (key !== mockReacterId) return undefined;
+
+    const mockMember = mockDeep<GuildMember>();
+    addMockGetter(mockMember, "id", key);
+    mockMember.user.id = key;
+
+    // (3) Mock role getting.
+    mockMember.roles.cache.has
+      .calledWith(BOT_DEV_RID)
+      .mockReturnValue(!!options.reacterIsDev);
+
+    return mockMember;
+  });
+}
+
+/**
+ * ACT.
+ *
+ * Simulate the emission of the `MessageReactionAdd` event using the prepared
+ * objects.
+ */
+async function simulateEmission(): Promise<void> {
+  const runner = new ListenerRunner(concertedReactSpec);
+  await runner.callbackToRegister(mockReaction, mockUser);
+}
+
+/**
+ * ASSERT.
+ *
+ * Check that the reaction was or wasn't copied.
+ */
+function assertReacted(reacted: boolean): void {
+  if (reacted) {
+    expect(mockReaction.message.react).toHaveBeenCalledWith(mockReaction.emoji);
+  }
+  else {
+    expect(mockReaction.message.react).not.toHaveBeenCalled();
+  }
+}
+
+it("should copy the dev's reaction if service is enabled", async () => {
+  arrangeEmission({ enabled: true, reacterIsDev: true });
+  await simulateEmission();
+  assertReacted(true);
+});
+
+it("should not copy reaction is reacter is not a dev", async () => {
+  arrangeEmission({ enabled: true, reacterIsDev: false });
+  await simulateEmission();
+  assertReacted(false);
+});
+
+it("should not copy reaction if service is disabled", async () => {
+  arrangeEmission({ enabled: false, reacterIsDev: true });
+  await simulateEmission();
+  assertReacted(false);
+});

--- a/tests/controllers/dev/control/set-concerted-react.command.test.ts
+++ b/tests/controllers/dev/control/set-concerted-react.command.test.ts
@@ -1,0 +1,52 @@
+import { bold } from "discord.js";
+
+import { BOT_DEV_RID, KAI_RID } from "../../../../src/config";
+import setConcertedReactSpec from "../../../../src/controllers/dev/control/set-concerted-react.command";
+import { RoleLevel } from "../../../../src/middleware/privilege.middleware";
+import devControlService from "../../../../src/services/dev-control.service";
+import { MockInteraction } from "../../../test-utils";
+
+let mock: MockInteraction;
+beforeEach(() => { mock = new MockInteraction(setConcertedReactSpec); });
+
+it("should require privilege level >= DEV", async () => {
+  mock
+    .mockCaller({ roleIds: [KAI_RID] })
+    .mockOption("Boolean", "enabled", true);
+  jest.replaceProperty(devControlService, "reactWithDev", false);
+
+  await mock.simulateCommand();
+
+  expect(devControlService.reactWithDev).toEqual(false); // i.e. Unchanged.
+  mock.expectMentionedMissingPrivilege(RoleLevel.DEV);
+});
+
+it("should set the service state to be true", async () => {
+  mock
+    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockOption("Boolean", "enabled", true);
+  jest.replaceProperty(devControlService, "reactWithDev", false);
+
+  await mock.simulateCommand();
+
+  expect(devControlService.reactWithDev).toEqual(true);
+  mock.expectRepliedWith({
+    ephemeral: true,
+    content: `${bold("Enabled")} concerted DEV reactions.`,
+  });
+});
+
+it("should set the service state to be false", async () => {
+  mock
+    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockOption("Boolean", "enabled", false);
+  jest.replaceProperty(devControlService, "reactWithDev", true);
+
+  await mock.simulateCommand();
+
+  expect(devControlService.reactWithDev).toEqual(false);
+  mock.expectRepliedWith({
+    ephemeral: true,
+    content: `${bold("Disabled")} concerted DEV reactions.`,
+  });
+});


### PR DESCRIPTION
## Overview

Another addition to the "dev control" utilities. This feature makes it so that the bot performs "concerted reactions" with any bot dev. That is, it copies all reactions bot devs make on messages. This gives off the goofy illusion that the bot is "always on the side" of a bot dev, such as when reacting to vote for something or just express satisfaction/dissatisfaction.

## Feature

* Added the `DEV` command `/set-concerted-react [enabled]` that sets whether this mode is enabled. This state is maintained in a new service/single source of truth, `DevControlService`.
* Added the `concerted-react` listener that checks that the service is enabled and that the reacter is a bot dev, and if so, copy the reaction. This is the first `Events.MessageReactionAdd` listener to the bot, so there are quite a few new patterns in the implemented controller and its corresponding tests.

## Other Changes

* Updated the list of Gateway intents as well as [discord.js partials](https://discordjs.guide/popular-topics/partials.html#enabling-partials) in the client ABC to enable listening for message reactions.