### PR TITLE
Include Spotify album links for #music-chat rxns

### DIFF
--- a/src/controllers/engagement/channel-react.listener.ts
+++ b/src/controllers/engagement/channel-react.listener.ts
@@ -50,7 +50,7 @@ function getEmojiToUse(message: Message): EmojiIdentifierResolvable | null {
   // Example link obtained from "Share > Copy Song Link":
   // https://open.spotify.com/track/5Yiwmn4PZAzVAms9UDICU2?si=67b6598c0b2d46aa
   const spotifyLinkPattern = new RegExp(
-    "\\bhttps://open\\.spotify\\.com/(track|playlist)/[a-zA-Z0-9]+" +
+    "\\bhttps://open\\.spotify\\.com/(track|playlist|album)/[a-zA-Z0-9]+" +
     "(\\?si=[a-zA-Z0-9]+)?\\b",
   );
 

--- a/tests/controllers/engagement/channel-react.listener.test.ts
+++ b/tests/controllers/engagement/channel-react.listener.test.ts
@@ -72,13 +72,35 @@ describe("PATTERN 2: messages that have no replies", () => {
   });
 });
 
-describe("PATTERN 3: Spotify song links", () => {
+describe("PATTERN 3: Spotify links", () => {
   it("should react to shared song links", async () => {
     mock
       .mockChannel({ cid: MUSIC_CHAT_CID })
       .mockContent(
         "yo this song is fire: https://open.spotify.com/track/" +
         "5Yiwmn4PZAzVAms9UDICU2?si=ae5ddf5fd3f345ce lol",
+      );
+    await mock.simulateEvent();
+    mock.expectReactedWith("🔥");
+  });
+
+  it("should react to shared playlist links", async () => {
+    mock
+      .mockChannel({ cid: MUSIC_CHAT_CID })
+      .mockContent(
+        "check out my playlist! https://open.spotify.com/playlist/" +
+        "5FpuSaX0kDeItlPMIIYBZS?si=14d4e45fc99e44e1 <3",
+      );
+    await mock.simulateEvent();
+    mock.expectReactedWith("🔥");
+  });
+
+  it("should react to shared album links", async () => {
+    mock
+      .mockChannel({ cid: MUSIC_CHAT_CID })
+      .mockContent(
+        "check out my playlist! https://open.spotify.com/album/" +
+        "08CvAj58nVMpq1Nw7T6maj?si=TXkSI8AKTNqmXTGt4L0Zdg <3",
       );
     await mock.simulateEvent();
     mock.expectReactedWith("🔥");


### PR DESCRIPTION
The `channel-react` listener now triggers on Spotify links for **albums** (in addition to **tracks** and **playlists**). Also added some tests to test triggering on these three conditions.