### PR TITLE
Fix ^ shorthand to use ~, like in Git notation

### DIFF
--- a/src/controllers/dev/control/dev-control-utils.ts
+++ b/src/controllers/dev/control/dev-control-utils.ts
@@ -50,20 +50,21 @@ export async function fetchMessageByIdentifier(
  * The `reference` option should support notation with the caret (`^`)
  * character, inspired by Git reference notation. Examples:
  *
- * - `^`: Last message. Also equivalent to `^1`.
- * - `^^^`: Third last message. Also equivalent to `^3`.
- * - `^5`: Fifth last message.
+ * - `^`: Last message. Also equivalent to `~1`.
+ * - `^^^`: Third last message. Also equivalent to `~3`.
+ * - `~5`: Fifth last message.
  *
  * Return a number representing the message's reverse position in the channel.
- * For example, return 3 for the third last message.
+ * For example, return 3 for the third last message. If the provided reference
+ * is not in valid caret notation, return null.
  */
 export function resolveCaretNotation(
   referenceId: string | null,
 ): number | null {
   if (referenceId === null) return null;
 
-  // ^N case.
-  const withNumberMatch = referenceId.match(/^\^(\d)+$/);
+  // ~N case.
+  const withNumberMatch = referenceId.match(/^~(\d+)$/);
   if (withNumberMatch) {
     const numCarets = Number(withNumberMatch[1]);
     if (isNaN(numCarets)) {

--- a/tests/controllers/dev/control/react.command.test.ts
+++ b/tests/controllers/dev/control/react.command.test.ts
@@ -89,8 +89,8 @@ describe("caret notation", () => {
     expectRepliedWithSucceededEmojis("🔥");
   });
 
-  it("should react to the 3rd most recent message (by ^3)", async () => {
-    mock.mockOption("String", "message", "^3");
+  it("should react to the 3rd most recent message (by ~3)", async () => {
+    mock.mockOption("String", "message", "~3");
     const mockMessage = mockChannelFetchMessage(mock, 3);
 
     await mock.simulateCommand();

--- a/tests/controllers/dev/control/send.command.test.ts
+++ b/tests/controllers/dev/control/send.command.test.ts
@@ -144,8 +144,8 @@ describe("replying to another message", () => {
       mock.expectRepliedGenericACK();
     });
 
-    it("should reply to the 3rd most recent message (by ^3)", async () => {
-      mock.mockOption("String", "reference", "^3");
+    it("should reply to the 3rd most recent message (by ~3)", async () => {
+      mock.mockOption("String", "reference", "~3");
       const mockMessage = mockChannelFetchMessage(mock, 3);
 
       await mock.simulateCommand();


### PR DESCRIPTION
This is in reference to the `reference` (no pun intended) option of the dev control commands, `/send` and `/react` (#89, #91).

Before, the notation treated `^N` as equivalent to N `^`'s. This notation is just shorthand to use within the context of our own bot, so it doesn't really matter in the sense that as long as we're consistent with what we defined things to be, there's no correctness issues.

However, since this shorthand is inspired by and intended to mirror [Git revision notation](https://git-scm.com/book/en/v2/Git-Tools-Revision-Selection), it would be better to be consistent with Git's semantics. Namely, `^N` in Git actually means the Nth parent and not Nth-degree ancestor. It is `~N` that is the shorthand for the latter, being equivalent to N `^'`s.