### PR TITLE
Refactor cooldown into a service

### DIFF
--- a/src/controllers/dev/cooldowns/cooldowns.autocomplete.ts
+++ b/src/controllers/dev/cooldowns/cooldowns.autocomplete.ts
@@ -1,5 +1,7 @@
 import { AutocompleteInteraction, Events } from "discord.js";
+
 import { BotClient } from "../../../bot/client";
+import cooldownService from "../../../services/cooldown.service";
 
 export async function listenerIdAutocomplete(
   interaction: AutocompleteInteraction,
@@ -8,12 +10,13 @@ export async function listenerIdAutocomplete(
   const client = interaction.client as BotClient;
 
   const listenersMap = client.getListenerSpecs(Events.MessageCreate);
-  const listenersWithCD = listenersMap.filter(
-    l => l.cooldown && l.cooldown.type !== "disabled",
-  );
+  const listenersWithCD = listenersMap.filter(listener => {
+    const manager = cooldownService.getManager(listener.id);
+    return manager && manager.type !== "disabled";
+  });
+
   const choiceObjs = listenersWithCD
     .filter(({ id }) => id.startsWith(focusedValue))
     .map(({ id }) => ({ name: id, value: id }));
-
   await interaction.respond(choiceObjs);
 }

--- a/src/controllers/dev/cooldowns/override-cooldown.command.ts
+++ b/src/controllers/dev/cooldowns/override-cooldown.command.ts
@@ -5,6 +5,7 @@ import {
   RoleLevel,
   checkPrivilege,
 } from "../../../middleware/privilege.middleware";
+import cooldownService from "../../../services/cooldown.service";
 import { CommandBuilder } from "../../../types/command.types";
 import { formatHoursMinsSeconds } from "../../../utils/dates.utils";
 import { getAllMembers } from "../../../utils/iteration.utils";
@@ -67,7 +68,7 @@ overrideCooldown.execute(async (interaction) => {
     return;
   }
 
-  const { cooldown } = listener;
+  const cooldown = cooldownService.getManager(listener.id);
 
   if (!cooldown || cooldown.type === "disabled") {
     await interaction.reply({
@@ -100,7 +101,7 @@ overrideCooldown.execute(async (interaction) => {
       });
       return;
     }
-    for (const member of members) {cooldown.setDuration(duration, member.id);}
+    for (const member of members) { cooldown.setDuration(duration, member.id); }
     await interaction.reply({
       content:
         `Set **${listenerId}** cooldown duration override for ` +
@@ -113,7 +114,7 @@ overrideCooldown.execute(async (interaction) => {
   }
 
   if (bypass !== null) {
-    for (const member of members) {cooldown.setBypass(bypass, member.id);}
+    for (const member of members) { cooldown.setBypass(bypass, member.id); }
     await interaction.reply({
       content:
         `${bypass ? "Enabled" : "Disabled"} **${listenerId}** bypass ` +

--- a/src/services/cooldown.service.ts
+++ b/src/services/cooldown.service.ts
@@ -1,0 +1,17 @@
+import { Collection } from "discord.js";
+
+import { CooldownManager } from "../middleware/cooldown.middleware";
+
+export class CooldownService {
+  private managers = new Collection<string, CooldownManager>();
+
+  public getManager(id: string): CooldownManager | null {
+    return this.managers.get(id) ?? null;
+  }
+
+  public setManager(id: string, manager: CooldownManager): void {
+    this.managers.set(id, manager);
+  }
+}
+
+export default new CooldownService();


### PR DESCRIPTION
Closes #37 (I think).

From https://github.com/vinlin24/yungkaiworldbot/issues/37#issuecomment-1928515738:

> I don't know why I didn't think of this earlier, but it would make more sense to have cooldown be a shared **service** that manages its state independent from the bot's operation. We really should not have attached `CooldownManager`s to specs and then loaded them onto the bot itself -- the motivation was to be able to "access" the cooldown managers again in different controllers, so I was tunnel-visioned on the solution of saving them on the bot itself. This has proven to cause many issues and clunky workarounds.

The whole `CooldownManager` inheritance hierarchy (#59) was untouched (to minimize breaking changes when refactoring ~~and also my sanity~~). Furthermore, the (now many) controllers still "see" the same interface of `<MessageListenerBuilder>.cooldown(<CooldownSpec>)`. The backwards-compatible change was simply:

1. Stop saving `CooldownManager` instances on `ListenerSpec`s themselves but rather have them be stored and maintained in a new `CooldownService` singleton. The managers can be retrieved and updated via ID through this service's minimal CRUD interface.
2. The `useCooldown` middleware function now takes some arbitrary ID and a `CooldownManager`, registers the manager with the service, and returns the same `ListenerFilter` closures like before.
3. `<MessageListenerBuilder>.cooldown` acts as a wrapper for `useCooldown`, making a call to it with the *listener's* ID as the cooldown ID and registering it as an event listener filter.
4. Fix errors from making the previous changes. It was mostly a matter of changing the pattern of `listener.spec.cooldown` (retrieving from the client itself) to `cooldownService.getManager(listener.id)` (retrieving from the service).

> [!IMPORTANT]
> TL;DR: `CooldownService` is now the single source of truth for cooldown state. Cooldown is now separate from listener specs themselves or the bot client.