### PR TITLE
feat: add filter for how long user's been a member

### DIFF
--- a/src/controllers/users/luke/dad-joke.listener.ts
+++ b/src/controllers/users/luke/dad-joke.listener.ts
@@ -1,4 +1,5 @@
 import {
+  authorHasBeenMemberFor,
   channelPollutionAllowed,
 } from "../../../middleware/filters.middleware";
 import lukeService from "../../../services/luke.service";
@@ -6,6 +7,8 @@ import { MessageListenerBuilder } from "../../../types/listener.types";
 
 const dadJoker = new MessageListenerBuilder().setId("dad-joke");
 
+// Don't weird out new members lol.
+dadJoker.filter(authorHasBeenMemberFor(1, "day"));
 dadJoker.filter(channelPollutionAllowed);
 dadJoker.execute(lukeService.processDadJoke);
 dadJoker.cooldown({ type: "user", defaultSeconds: 600 });

--- a/tests/middleware/filters.middleware.test.ts
+++ b/tests/middleware/filters.middleware.test.ts
@@ -13,6 +13,7 @@ import { GuildTextBasedChannel, Message } from "discord.js";
 
 /* eslint-disable import-newlines/enforce */
 import {
+  authorHasBeenMemberFor,
   channelPollutionAllowed,
   channelPollutionAllowedOrBypass,
   containsCustomEmoji,
@@ -225,5 +226,35 @@ describe("checking for emojis", () => {
       const passed = closure(message);
       expect(passed).toEqual(false);
     });
+  });
+});
+
+describe("checking author membership time", () => {
+  const ONE_DAY_NUM_MILLISECONDS = 24 * 60 * 60 * 1000;
+
+  it("should pass if member has been a member for long enough", () => {
+    const message = {
+      member: {
+        joinedTimestamp: Date.now() - (ONE_DAY_NUM_MILLISECONDS * 2),
+      },
+    } as Message;
+    const closure = authorHasBeenMemberFor(1, "day");
+
+    const passed = closure(message);
+
+    expect(passed).toEqual(true);
+  });
+
+  it("shouldn't pass if member hasn't been a member for long enough", () => {
+    const message = {
+      member: {
+        joinedTimestamp: Date.now(),
+      },
+    } as Message;
+    const closure = authorHasBeenMemberFor(1, "day");
+
+    const passed = closure(message);
+
+    expect(passed).toEqual(false);
   });
 });


### PR DESCRIPTION
This may be useful for message listeners we do not want to activate on new members.

To start, the Dad joke message listener has been configured with this new filter with a setting of 1 day.