### PR TITLE
feat: add "im so silly" variant of dad joke

### DIFF
--- a/src/controllers/users/luke/dad-joke.listener.ts
+++ b/src/controllers/users/luke/dad-joke.listener.ts
@@ -1,3 +1,4 @@
+import env from "../../../config";
 import {
   authorHasBeenMemberFor,
   channelPollutionAllowed,
@@ -11,7 +12,12 @@ const dadJoker = new MessageListenerBuilder().setId("dad-joke");
 dadJoker.filter(authorHasBeenMemberFor(1, "day"));
 dadJoker.filter(channelPollutionAllowed);
 dadJoker.execute(lukeService.processDadJoke);
-dadJoker.cooldown({ type: "user", defaultSeconds: 600 });
+dadJoker.cooldown({
+  type: "user",
+  defaultSeconds: 600,
+  // Crude workaround for the "im so silly" variant.
+  overrides: new Map([[env.NI_UID, 0]]),
+});
 
 const dadJokeSpec = dadJoker.toSpec();
 export default dadJokeSpec;

--- a/src/middleware/cooldown.middleware.ts
+++ b/src/middleware/cooldown.middleware.ts
@@ -240,8 +240,13 @@ export abstract class PerIDCooldownManager<
   }
 
   public override setBypass(bypass: boolean, discordId: string): void {
-    if (bypass) this.overrides.set(discordId, 0);
-    else this.overrides.delete(discordId); // ID falls back to defaultSeconds.
+    if (bypass) {
+      this.overrides.set(discordId, 0);
+      this.expirations.delete(discordId); // Clear existing cooldown, if exists.
+    }
+    else {
+      this.overrides.delete(discordId);
+    } // ID falls back to defaultSeconds.
   }
 
   public override dump(): DumpType {

--- a/src/middleware/filters.middleware.ts
+++ b/src/middleware/filters.middleware.ts
@@ -49,9 +49,6 @@ export function messageFromRoles(
 export function isPollutionImmuneChannel(
   channel: GuildTextBasedChannel,
 ): boolean {
-  // Might be best to not annoy the kiddos too much.
-  if (channel.name.indexOf("general") !== -1) return true;
-
   // Don't pollute important channels.
   const importantSubstrings = ["introductions", "announcements", "welcome"];
   if (importantSubstrings.some(s => channel.name.indexOf(s) !== -1)) {

--- a/src/services/luke.service.ts
+++ b/src/services/luke.service.ts
@@ -28,7 +28,7 @@ export class LukeService {
     const [, notPresent, captured] = matches;
 
     let response: string;
-    let jokeType: "negative" | "affirmative" | "welcome";
+    let jokeType: "negative" | "affirmative" | "welcome" | "silly";
 
     // Negative version of the joke.
     if (notPresent) {
@@ -41,6 +41,10 @@ export class LukeService {
     else if (captured.match(/^(back|awake|up|here|alive)[.~!?-]*$/i)) {
       response = `Welcome back, ${author.displayName}!`;
       jokeType = "welcome";
+    }
+    else if (captured.trim().toLowerCase() === "so silly") {
+      response = "ur so silly";
+      jokeType = "silly";
     }
     else {
       response = `Hi ${captured}, I'm ${message.client.user.displayName}!`;

--- a/src/services/luke.service.ts
+++ b/src/services/luke.service.ts
@@ -42,7 +42,7 @@ export class LukeService {
       response = `Welcome back, ${author.displayName}!`;
       jokeType = "welcome";
     }
-    else if (captured.trim().toLowerCase() === "so silly") {
+    else if (this.isSillyVariant(captured)) {
       response = "ur so silly";
       jokeType = "silly";
     }
@@ -57,6 +57,12 @@ export class LukeService {
     );
     return true;
   };
+
+  private isSillyVariant(captured: string): boolean {
+    captured = captured.trim();
+    captured = captured.replace(/[^a-z]/gi, "");
+    return captured.startsWith("sosilly");
+  }
 }
 
 export default new LukeService();

--- a/tests/controllers/users/klee/dab.listener.test.ts
+++ b/tests/controllers/users/klee/dab.listener.test.ts
@@ -21,7 +21,7 @@ describe("dab listener", () => {
   });
 
   it("should react with neko L in pollution-immune channel", async () => {
-    mock.mockContent("dab").mockChannel({ name: "general" });
+    mock.mockContent("dab").mockChannel({ name: "welcome" });
     await mock.simulateEvent();
     mock.expectReactedWith(GUILD_EMOJIS.NEKO_L);
   });

--- a/tests/middleware/filters.middleware.test.ts
+++ b/tests/middleware/filters.middleware.test.ts
@@ -69,7 +69,6 @@ describe("messageFrom middleware", () => {
 
 describe("channel pollution", () => {
   const IMPORTANT_CHANNELS = [
-    "general",
     "introductions",
     "staff-introductions",
     "announcements",


### PR DESCRIPTION
Feature requested by user Ni:

![image](https://github.com/vinlin24/yungkaiworldbot/assets/67369899/dd5aabb8-aef9-402f-8196-d5913b177366)

For simplicity, this feature was simply meshed into the existing dad joke listener. Modified spec:

* Added bypass override for Ni (duration 0). This applies to ALL dad jokes, so it's just a crude workaround for them being able to bypass cooldown for at least the "im so silly" variant for now.

Other changes:

* Channels that have "general" in their name are no longer included in the channel pollution prevention policy.
* Fix a bug in `PerIDCooldownManager#setBypass`. Previously, setting bypass to true for an ID may still result in the cooldown being treated as active for that ID since the cooldown in the expirations mapping was not cleared.