### PR TITLE
refactor: use UIDs for DEV privilege

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,10 @@ KAI_UID=
 NI_UID=
 S_UID=
 WYS_UID=
+CODIE_UID=
+
+# Users recognized as developers (comma-separated user IDs).
+DEVELOPER_UIDS=
 
 # Discord bot IDs.
 CLIENT_UID=

--- a/src/config.ts
+++ b/src/config.ts
@@ -39,4 +39,11 @@ export const ALPHA_MOD_RID = "1102008787340103682";
 export const BABY_MOD_RID = "1162114191876960318";
 
 const { env } = process;
+
+/**
+ * Temporary (?) workaround for the security concerns of having a dedicated
+ * developer role. We'll hard-code developer UIDs into the environment file.
+ */
+export const DEVELOPER_UIDS = env.DEVELOPER_UIDS.split(",").map(s => s.trim());
+
 export default env;

--- a/src/middleware/privilege.middleware.ts
+++ b/src/middleware/privilege.middleware.ts
@@ -1,6 +1,17 @@
-import { CommandInteraction, GuildMember, roleMention } from "discord.js";
+import {
+  bold,
+  CommandInteraction,
+  GuildMember,
+  inlineCode,
+  underscore,
+} from "discord.js";
 
-import { ALPHA_MOD_RID, BABY_MOD_RID, BOT_DEV_RID, KAI_RID } from "../config";
+import {
+  ALPHA_MOD_RID,
+  BABY_MOD_RID,
+  DEVELOPER_UIDS,
+  KAI_RID,
+} from "../config";
 import getLogger from "../logger";
 import { CommandCheck } from "../types/command.types";
 import { formatContext } from "../utils/logging.utils";
@@ -33,15 +44,30 @@ export enum RoleLevel {
   DEV,
 }
 
-export const LEVEL_TO_RID: Record<
-  Exclude<RoleLevel, RoleLevel.NONE>,
-  string
-> = {
-  [RoleLevel.DEV]: BOT_DEV_RID,
-  [RoleLevel.KAI]: KAI_RID,
-  [RoleLevel.ALPHA_MOD]: ALPHA_MOD_RID,
-  [RoleLevel.BABY_MOD]: BABY_MOD_RID,
-};
+function highestPrivilegeLevel(member: GuildMember): RoleLevel {
+  if (DEVELOPER_UIDS.includes(member.user.id)) {
+    return RoleLevel.DEV;
+  }
+  if (member.roles.cache.has(KAI_RID)) {
+    return RoleLevel.KAI;
+  }
+  if (member.roles.cache.has(ALPHA_MOD_RID)) {
+    return RoleLevel.ALPHA_MOD;
+  }
+  if (member.roles.cache.has(BABY_MOD_RID)) {
+    return RoleLevel.BABY_MOD;
+  }
+  return RoleLevel.NONE;
+}
+
+export function isAuthorized(
+  member: GuildMember,
+  requestLevel: RoleLevel,
+): boolean {
+  // As long as the level required by the command is less than any of the levels
+  // for which the caller has a role, then they pass.
+  return requestLevel <= highestPrivilegeLevel(member);
+}
 
 export function checkPrivilege(
   commandLevel: RoleLevel,
@@ -49,46 +75,27 @@ export function checkPrivilege(
 ): boolean;
 export function checkPrivilege(commandLevel: RoleLevel): CommandCheck;
 export function checkPrivilege(
-  commandLevel: RoleLevel,
+  requestLevel: RoleLevel,
   memberToCheck?: GuildMember,
 ): boolean | CommandCheck {
-  function isAuthorized(member: GuildMember): boolean {
-    for (const level of Object.keys(LEVEL_TO_RID)) {
-      const levelValue = Number(level) as Exclude<RoleLevel, RoleLevel.NONE>;
-      const roleId = LEVEL_TO_RID[levelValue];
-      // As long as the level required by the command is less than any of the
-      // levels for which the caller has a role, then they pass.
-      if (commandLevel <= levelValue && member.roles.cache.has(roleId)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   if (memberToCheck) {
-    return isAuthorized(memberToCheck);
+    return isAuthorized(memberToCheck, requestLevel);
   }
 
   function predicate(interaction: CommandInteraction): boolean {
     const member = interaction.member as GuildMember;
-    return isAuthorized(member);
+    return isAuthorized(member, requestLevel);
   }
 
   async function onFail(interaction: CommandInteraction): Promise<void> {
     const member = interaction.member as GuildMember;
 
-    if (commandLevel === RoleLevel.NONE) { // Pacify LEVEL_TO_RID lookup.
-      throw new Error("commandLevel was NONE, check shouldn't have failed.");
-    }
-    const minimumRoleId = LEVEL_TO_RID[commandLevel];
-    const mention = roleMention(minimumRoleId);
     const reason = (
-      "minimum required privilege level: " +
-      `\`${RoleLevel[commandLevel]}\` (${mention})`
+      `minimum required privilege level: ${inlineCode(RoleLevel[requestLevel])}`
     );
     const response = (
-      `**${member.user.username}**, you're not allowed to use this command!` +
-      `\n__Reason__: ${reason}.`
+      `${bold(member.user.username)}, you're not allowed to use this command!` +
+      `\n${underscore("Reason")}: ${reason}.`
     );
 
     const context = formatContext(interaction);

--- a/src/types/env.d.ts
+++ b/src/types/env.d.ts
@@ -48,6 +48,9 @@ declare global {
     NI_UID: string;
     S_UID: string;
     WYS_UID: string;
+    CODIE_UID: string;
+
+    DEVELOPER_UIDS: string;
 
     // ///////////////////////// //
     //      Discord Bot IDs      //

--- a/tests/controllers/dev/control/react.command.test.ts
+++ b/tests/controllers/dev/control/react.command.test.ts
@@ -1,7 +1,7 @@
 import { Collection, Message, inlineCode } from "discord.js";
 import { mockDeep } from "jest-mock-extended";
 
-import { BOT_DEV_RID, KAI_RID } from "../../../../src/config";
+import { KAI_RID } from "../../../../src/config";
 import devReactSpec from "../../../../src/controllers/dev/control/react.command";
 import { RoleLevel } from "../../../../src/middleware/privilege.middleware";
 import { MockInteraction } from "../../../test-utils";
@@ -33,7 +33,7 @@ it("should require privilege level >= DEV", async () => {
 
 it("should react to the most recent message", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "emojis", "🤩");
   const mockMessage = mockDeep<Message<true>>();
   mock.interaction.channel!.messages.fetch
@@ -47,7 +47,7 @@ it("should react to the most recent message", async () => {
 
 it("should react to the specified message (using ID)", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "emojis", "🫡")
     .mockOption("String", "message", dummyMessageId);
   const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
@@ -61,7 +61,7 @@ it("should react to the specified message (using ID)", async () => {
 it("should react to the specified message (using URL)", async () => {
   const dummyUrl = `https://discord.com/channels/3344/6677/${dummyMessageId}`;
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "emojis", "😪")
     .mockOption("String", "message", dummyUrl);
   const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
@@ -75,7 +75,7 @@ it("should react to the specified message (using URL)", async () => {
 describe("caret notation", () => {
   beforeEach(() => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", "🔥");
   });
 
@@ -103,7 +103,7 @@ describe("caret notation", () => {
 describe("error handling", () => {
   it("should reject invalid emojis", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", "😨");
     const mockMessage = mockChannelFetchMessage(mock);
     mockMessage.react.mockRejectedValueOnce("DUMMY-ERROR");
@@ -120,7 +120,7 @@ describe("error handling", () => {
 
   it("should reject invalid message identifiers", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", "😨")
       .mockOption("String", "message", "lmao");
 
@@ -134,7 +134,7 @@ describe("error handling", () => {
 
   it("should reject input strings without any emojis", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", "lorem ipsum");
 
     await mock.simulateCommand();
@@ -151,7 +151,7 @@ describe("error handling", () => {
 describe("multiple emojis at once", () => {
   it("should react with all emojis in the string", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", "hello 💯 there 🥳!")
       .mockOption("String", "message", dummyMessageId);
     const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
@@ -166,7 +166,7 @@ describe("multiple emojis at once", () => {
   it("should work with both Unicode and custom emojis", async () => {
     const dummyCustomEmoji = "<:customEmoji:4242424242>";
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", `general ${dummyCustomEmoji} kenobi 😠!`)
       .mockOption("String", "message", dummyMessageId);
     const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
@@ -180,7 +180,7 @@ describe("multiple emojis at once", () => {
 
   it("should continue reacting even on a failed reaction", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "emojis", "wow ❌ amazing ✅ lol")
       .mockOption("String", "message", dummyMessageId);
     const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);

--- a/tests/controllers/dev/control/send.command.test.ts
+++ b/tests/controllers/dev/control/send.command.test.ts
@@ -1,7 +1,7 @@
 import { GuildTextBasedChannel, Message, MessageFlags } from "discord.js";
 import { DeepMockProxy } from "jest-mock-extended";
 
-import { BOT_DEV_RID, KAI_RID } from "../../../../src/config";
+import { KAI_RID } from "../../../../src/config";
 import devSendSpec from "../../../../src/controllers/dev/control/send.command";
 import { RoleLevel } from "../../../../src/middleware/privilege.middleware";
 import { MockInteraction } from "../../../test-utils";
@@ -24,7 +24,7 @@ it("should require privilege level >= DEV", async () => {
 
 it("should forward content to current channel", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "content", "hello there");
   await mock.simulateCommand();
   expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
@@ -36,7 +36,7 @@ it("should forward content to current channel", async () => {
 it("should forward content to specified channel", async () => {
   const mockChannel = { send: jest.fn() } as unknown as GuildTextBasedChannel;
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "content", "general kenobi")
     .mockOption<GuildTextBasedChannel>("Channel", "channel", mockChannel);
   await mock.simulateCommand();
@@ -48,7 +48,7 @@ it("should forward content to specified channel", async () => {
 
 it("should enable mentions by default", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "content", "you are a bold one");
   await mock.simulateCommand();
   expect(mock.interaction.channel!.send).toHaveBeenCalledWith(
@@ -62,7 +62,7 @@ it("should enable mentions by default", async () => {
 
 it("should disable mentions if explicitly specified", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "content", "you're shorter than i expected")
     .mockOption("Boolean", "silent", true);
   await mock.simulateCommand();
@@ -92,7 +92,7 @@ describe("replying to another message", () => {
 
   it("should reply to the correct message (using ID)", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "content", "jedi scum")
       .mockOption("String", "reference", dummyMessageId);
     const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
@@ -106,7 +106,7 @@ describe("replying to another message", () => {
   it("should reply to the correct message (using URL)", async () => {
     const dummyUrl = `https://discord.com/channels/3344/6677/${dummyMessageId}`;
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "content", "it's over anakin")
       .mockOption("String", "reference", dummyUrl);
     const mockMessage = mockChannelFetchMessageById(mock, dummyMessageId);
@@ -120,7 +120,7 @@ describe("replying to another message", () => {
   describe("caret notation", () => {
     beforeEach(() => {
       mock
-        .mockCaller({ roleIds: [BOT_DEV_RID] })
+        .mockCallerIsDev()
         .mockOption("String", "content", "i have the high ground");
     });
 
@@ -157,7 +157,7 @@ describe("replying to another message", () => {
 
   it("should reject invalid message identifiers", async () => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("String", "content", "you underestimate my power")
       .mockOption("String", "reference", "don't try it");
 

--- a/tests/controllers/dev/control/set-concerted.command.test.ts
+++ b/tests/controllers/dev/control/set-concerted.command.test.ts
@@ -1,6 +1,6 @@
 import { bold } from "discord.js";
 
-import { BOT_DEV_RID, KAI_RID } from "../../../../src/config";
+import { KAI_RID } from "../../../../src/config";
 import setConcertedReactSpec from "../../../../src/controllers/dev/control/set-concerted.command";
 import { RoleLevel } from "../../../../src/middleware/privilege.middleware";
 import devControlService from "../../../../src/services/dev-control.service";
@@ -23,7 +23,7 @@ it("should require privilege level >= DEV", async () => {
 
 it("should set the service state to be true", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("Boolean", "reactions_enabled", true);
   jest.replaceProperty(devControlService, "reactWithDev", false);
 
@@ -40,7 +40,7 @@ it("should set the service state to be true", async () => {
 
 it("should set the service state to be false", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("Boolean", "reactions_enabled", false);
   jest.replaceProperty(devControlService, "reactWithDev", true);
 

--- a/tests/controllers/dev/presence.command.test.ts
+++ b/tests/controllers/dev/presence.command.test.ts
@@ -6,7 +6,7 @@ import {
   PresenceUpdateStatus,
 } from "discord.js";
 
-import { BOT_DEV_RID, KAI_RID } from "../../../src/config";
+import { KAI_RID } from "../../../src/config";
 import presenceSpec, {
   ActivityTypeName,
   PresenceUpdateStatusName,
@@ -36,7 +36,7 @@ it("should require privilege >= DEV", async () => {
 
 it("should clear the activity as long as the flag is set", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("Boolean", "clear_activity", true)
     .mockOption("String", "activity_name", "unit testing!");
 
@@ -49,7 +49,7 @@ it("should clear the activity as long as the flag is set", async () => {
 
 it("should disallow providing an activity type without a name", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption<ActivityTypeName>("String", "activity_type", "Listening");
 
   await mock.simulateCommand();
@@ -64,7 +64,7 @@ it("should disallow providing an activity type without a name", async () => {
 
 it("should set the activity name if provided", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "activity_name", "unit testing!");
 
   await mock.simulateCommand();
@@ -85,7 +85,7 @@ it("should set the activity name if provided", async () => {
 
 it("should set the activity name with type if provided", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("String", "activity_name", "unit testing!")
     .mockOption<ActivityTypeName>("String", "activity_type", "Listening");
 
@@ -107,7 +107,7 @@ it("should set the activity name with type if provided", async () => {
 
 it("should set the status if provided", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption<PresenceUpdateStatusName>("String", "status", "Idle");
 
   await mock.simulateCommand();
@@ -121,7 +121,7 @@ it("should set the status if provided", async () => {
 
 it("should set everything if all provided", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption<PresenceUpdateStatusName>("String", "status", "Idle")
     .mockOption<ActivityTypeName>("String", "activity_type", "Listening")
     .mockOption("String", "activity_name", "unit testing!");

--- a/tests/controllers/dev/reload.command.test.ts
+++ b/tests/controllers/dev/reload.command.test.ts
@@ -3,7 +3,7 @@ jest.mock("../../../src/utils/meta.utils");
 import { EmbedBuilder } from "discord.js";
 import { Matcher } from "jest-mock-extended";
 
-import { BOT_DEV_RID, KAI_RID } from "../../../src/config";
+import { KAI_RID } from "../../../src/config";
 import reloadSpec from "../../../src/controllers/dev/reload.command";
 import { getCurrentBranchName } from "../../../src/utils/meta.utils";
 import { MockInteraction } from "../../test-utils";
@@ -38,7 +38,7 @@ it("should require privilege level >= DEV", async () => {
 
 it("should clear defs, deploy commands, and reload defs", async () => {
   mock
-    .mockCaller({ roleIds: [BOT_DEV_RID] })
+    .mockCallerIsDev()
     .mockOption("Boolean", "redeploy_slash_commands", true);
 
   await mock.simulateCommand();
@@ -51,7 +51,7 @@ it("should clear defs, deploy commands, and reload defs", async () => {
 });
 
 it("shouldn't deploy commands if option not explicitly set", async () => {
-  mock.mockCaller({ roleIds: [BOT_DEV_RID] });
+  mock.mockCallerIsDev();
 
   await mock.simulateCommand();
 
@@ -63,7 +63,7 @@ it("shouldn't deploy commands if option not explicitly set", async () => {
 });
 
 it("should update the client's branch name", async () => {
-  mock.mockCaller({ roleIds: [BOT_DEV_RID] });
+  mock.mockCallerIsDev();
   mockedGetCurrentBranchName.mockReturnValueOnce("DUMMY-BRANCH-NAME");
 
   await mock.simulateCommand();
@@ -73,7 +73,7 @@ it("should update the client's branch name", async () => {
 
 describe("stealth mode setting", () => {
   beforeEach(() => {
-    mock.mockCaller({ roleIds: [BOT_DEV_RID] });
+    mock.mockCallerIsDev();
   });
 
   it("should reload with stealth mode enabled", async () => {
@@ -106,7 +106,7 @@ describe("stealth mode setting", () => {
 describe("error handling", () => {
   beforeEach(() => {
     mock
-      .mockCaller({ roleIds: [BOT_DEV_RID] })
+      .mockCallerIsDev()
       .mockOption("Boolean", "redeploy_slash_commands", true);
 
     // Also suppress console.error output.

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -20,6 +20,7 @@ import { fromZodError } from "zod-validation-error";
 
 import { CommandRunner } from "../src/bot/command.runner";
 import { ListenerRunner } from "../src/bot/listener.runner";
+import { DEVELOPER_UIDS } from "../src/config";
 import { RoleLevel } from "../src/middleware/privilege.middleware";
 import cooldownService from "../src/services/cooldown.service";
 import { ClientWithIntentsAndRunnersABC } from "../src/types/client.abc";
@@ -140,6 +141,18 @@ export class MockInteraction {
       mockRoles(member, options.roleIds);
     }
 
+    return this;
+  }
+
+  /**
+   * ARRANGE.
+   *
+   * Mock that the caller is one of the developers. Shorthand for using
+   * `mockCaller` with a specific developer UID.
+   */
+  public mockCallerIsDev(): this {
+    const member = this.interaction.member as DeepMockProxy<GuildMember>;
+    member.user.id = DEVELOPER_UIDS[0];
     return this;
   }
 


### PR DESCRIPTION
## Motivation

There are some concerns with the current approach of identifying developer programmatically through a "developers" **role** within Discord: Namely, to protect that role from privilege escalation, the role needs to be hoisted above most other roles in the role hierarchy. This itself has some issues:
- Security: Having a role high up in the hierarchy also elevates the moderation permissions of members in that role. For example, assuming they have proper permissions granted by other roles, they could manage roles, change nickname of, timeout/kick/ban/etc. anyone below them, including other moderators.
- Cosmetic: A member's display color is determined by their highest role, even if not displayed separately on the sidebar. This ruins the color theme of the member's intended displayed role e.g. "moderator".

The easiest solution would be to:
1. Within Discord, turn the existing "developers" role to a simple **vanity role** (for identification and pinging).
2. Within code: manually check for hard-coded **user IDs** to determine if someone is a developer.

The trade-off is that since we are no longer using Discord as the source of truth, maintenance of the developer IDs in the environment file needs to be kept in lock step with changes in the development team. Since new developers are once in a blue moon, that shouldn't be a big problem.

## Changes

This PR:
- [x] Adds a new member to the developer list.
- [x] Updates the environment file requirement to include the developer UIDs.
- [x] Revamps the implementation of the privilege-checking middleware:
  - The `RoleLevel` enum, despite its name, no longer necessarily maps to role IDs.
  - `isAuthorized()` now manually checks with an `if`-`else` ladder for the `highestPrivilegeLevel()` of a given member. For the `DEV` level, it checks if the member UID is one of the recognized developer UIDs.
- [x] Updates all tests that fail as a result of the above changes. Namely, since `BOT_DEV_RID` is no longer used, mocking that role on the dummy members no longer does anything. Such mocks have been replaced with a new `.mockCallerIsDev()` helper method.